### PR TITLE
Update naughtyURLs.txt

### DIFF
--- a/Lists/naughtyURLs.txt
+++ b/Lists/naughtyURLs.txt
@@ -47,9 +47,9 @@ starbucksiswrong.com
 yoütübe.co
 yoütübe.com
 youtubeshort.watch
-cdn.discordapp.com/attachments/772417751540170792/799443986922078218/luag.mp4
-cdn.discordapp.com/attachments/797952536585175120/797955696544317450/video0_9_1.mp4
-cdn.discordapp.com/attachments/724055819548622968/797952645662244864/swag.mp4
-cdn.discordapp.com/attachments/795175839360483349/795192712419999774/india.mp4 
-cdn.discordapp.com/attachments/430460197555666978/795437654467543060/video0-44.mp4
+/luag.mp4
+/video0_9_1.mp4
+/swag.mp4
+/india.mp4 
+/video0-44.mp4
 pornhub.com/view_video.php


### PR DESCRIPTION
People keep posting these same videos uploaded to different server channels, since they're pretty uncommon names its probably better to filter them out like this (slash included so people won't get warned for just mentioning the file name) and then in the unlikely event someone wants to upload a non-malicious video called "video0_9_1.mp4" then we can remove the warning