### PR TITLE
shorten dehoisted 32char nicks *by* 1char, not *to* 1char

### DIFF
--- a/Modules/GenericModCmds.cs
+++ b/Modules/GenericModCmds.cs
@@ -437,7 +437,7 @@ namespace MicrosoftBot.Modules
 
                     if (origName.Length == 32)
                     {
-                        origName = origName.Substring(origName.Length - 1);
+                        origName = origName.Substring(0, origName.Length - 1);
                     }
                     var newName = $"\u17b5{origName}";
                     try


### PR DESCRIPTION
Someone thought that apparently this was a mistake, but in reality just screw people with long annoying nicknames, they deserve to be knocked down to one character. Eh, better fix it so people don't think its a "bug"