### PR TITLE
Add dumb spam site

### DIFF
--- a/Lists/naughtyURLs.txt
+++ b/Lists/naughtyURLs.txt
@@ -53,3 +53,4 @@ youtubeshort.watch
 /india.mp4 
 /video0-44.mp4
 pornhub.com/view_video.php
+savediscord.com


### PR DESCRIPTION
preemptively adding, site seems to be spreading around Discord, also requests users to authenticate then publicly lists users who have. Claims to be "raising money to save Discord" (complete BS since it just counts people's Nitro). At best it'll just be used for annoying spam, at worst its harvesting users for Something™️. Either way, seems sensible to just block it AOT