### PR TITLE
Whitelist discord.gg/xbox from invite auto-warn

### DIFF
--- a/Modules/ConfigJson.cs
+++ b/Modules/ConfigJson.cs
@@ -95,7 +95,7 @@ namespace Cliptok
         public List<ulong> TierRoles { get; private set; }
 
         [JsonProperty("inviteExclusion")]
-        public string InviteExclusion { get; private set; }
+        public List<string> InviteExclusion { get; private set; }
 
         [JsonProperty("inviteTierRequirement")]
         public int InviteTierRequirement { get; private set; }

--- a/Program.cs
+++ b/Program.cs
@@ -321,15 +321,16 @@ namespace Cliptok
                 // Unapproved invites
                 if (Warnings.GetPermLevel(member) < (ServerPermLevel)cfgjson.InviteTierRequirement)
                 {
-                    string inviteExclusion = cfgjson.InviteExclusion;
-                    if (cfgjson.InviteExclusion != null)
-                        inviteExclusion = cfgjson.InviteExclusion;
 
-                    string checkedMessage = e.Message.Content.Replace($"discord.gg/{inviteExclusion}", "").Replace($"discord.com/invite/{inviteExclusion}", "").Replace('\\', '/');
+                    string checkedMessage = e.Message.Content.Replace('\\', '/');
+                    foreach (string exclusion in cfgjson.InviteExclusion)
+                    {
+                        checkedMessage = checkedMessage.Replace("discord.gg/" + exclusion, "").Replace("discord.com/invite/" + exclusion, "");
+                    }
 
                     if (checkedMessage.Contains("discord.gg/") || checkedMessage.Contains("discord.com/invite/"))
                     {
-                        string reason = "Sent an invite";
+                        string reason = "Sent an unapproved invite";
                         e.Message.DeleteAsync();
                         try
                         {

--- a/config.json
+++ b/config.json
@@ -13,7 +13,10 @@
   "homeChannel": 793285213823172628,
   "investigationsChannel": 745276933767430255,
   "warningDaysThreshold": 30,
-  "inviteExclusion": "microsoft",
+  "inviteExclusion": {
+    "microsoft",
+    "xbox",
+  },
   "autoMuteThresholds": {
     "2": 6,
     "4": 12,

--- a/config.json
+++ b/config.json
@@ -13,10 +13,10 @@
   "homeChannel": 793285213823172628,
   "investigationsChannel": 745276933767430255,
   "warningDaysThreshold": 30,
-  "inviteExclusion": {
+  "inviteExclusion": [
     "microsoft",
-    "xbox",
-  },
+    "xbox"
+  ],
   "autoMuteThresholds": {
     "2": 6,
     "4": 12,


### PR DESCRIPTION
The Xbox server is verified and people often refer others to it for support. Unfortunately, those who are Tier 1 seem to do this more often than you'd expect, so they're often warned just for sending a link to the Xbox server. Whitelisting it would solve this problem, and it's a trusted server so there shouldn't be any concern about whitelisting it.