### PR TITLE
Add gfycat crashing gif

### DIFF
--- a/Lists/naughtyURLs.txt
+++ b/Lists/naughtyURLs.txt
@@ -59,4 +59,5 @@ tornadus.net/orange
 pnrtscr.com
 NeatPhonyAcornweevil.mp4
 BabyishDiscreteCatbird-size_restricted.gif
+gfycat.com/sizzlingscrawnybudgie
 ||​||||​||||​||


### PR DESCRIPTION
Since it's an auto-generated three words URL link, I added gfycat.com at the start, so it doesn't conflict with other uploading services that create random words