### PR TITLE
Add discordofficial.com - Free nitro scam

### DIFF
--- a/Lists/naughtyURLs.txt
+++ b/Lists/naughtyURLs.txt
@@ -61,3 +61,4 @@ NeatPhonyAcornweevil.mp4
 BabyishDiscreteCatbird-size_restricted.gif
 gfycat.com/sizzlingscrawnybudgie
 ||​||||​||||​||
+discordofficial.com


### PR DESCRIPTION
Website at subdomain claim.discordofficial.com prompts you to sign in with a discord oauth2 application then forwards you to the root domain to redirect you a couple times to download suspicious main.exe file (https://www.virustotal.com/gui/file/3874db0907cad6f8ca31b2bdc32f09f1a68dfa73a34c5287cf63c2bc223d2e35/detection) and join a invite for nitro discord server.