### PR TITLE
Whitelist invites for 'affiliated' servers

### DIFF
--- a/config.json
+++ b/config.json
@@ -23,7 +23,12 @@
     "microsoft",
     "xbox",
     "FjJfTZdtXg",
-    "cMxFErsEDB"
+    "cMxFErsEDB",
+    "apple",
+    "google",
+    "iphone",
+    "directx",
+    "winadmins"
   ],
   "autoMuteThresholds": {
     "2": 6,


### PR DESCRIPTION
r/Apple, r/Google, r/iPhone, DirectX, Windows Admins

We're not associated with DirectX or Windows Admins, but they're Microsoft-related so they can be whitelisted as well