### PR TITLE
Report system feature implementation

### DIFF
--- a/Cliptok.csproj
+++ b/Cliptok.csproj
@@ -10,10 +10,10 @@
 
 	<ItemGroup>
 		<PackageReference Include="Abyssal.HumanDateParser" Version="2.0.0-20191113.1" />
-		<PackageReference Include="DSharpPlus" Version="4.1.0-nightly-00892" />
-		<PackageReference Include="DSharpPlus.CommandsNext" Version="4.1.0-nightly-00892" />
+		<PackageReference Include="DSharpPlus" Version="4.0.1" />
+		<PackageReference Include="DSharpPlus.CommandsNext" Version="4.0.1" />
 		<PackageReference Include="IDoEverything.DSharpPlus.SlashCommands" Version="1.4.2" />
-		<PackageReference Include="StackExchange.Redis" Version="2.2.4" />
+		<PackageReference Include="StackExchange.Redis" Version="2.2.62" />
 		<PackageReference Include="System.Linq" Version="4.3.0" />
 	</ItemGroup>
 

--- a/Modules/ConfigJson.cs
+++ b/Modules/ConfigJson.cs
@@ -61,6 +61,12 @@ namespace Cliptok
         [JsonProperty("logChannel")]
         public ulong LogChannel { get; private set; }
 
+        [JsonProperty("pendingReportsChannel")]
+        public ulong PendingReportsChannel { get; private set; }
+
+        [JsonProperty("reviewedReportsChannel")]
+        public ulong ReviewedReportsChannel { get; private set; }
+
         [JsonProperty("serverID")]
         public ulong ServerID { get; private set; }
 
@@ -147,6 +153,9 @@ namespace Cliptok
 
         [JsonProperty("modmailUserId")]
         public ulong ModmailUserId { get; private set; }
+
+        [JsonProperty("reports")]
+        public ReportsConfig reportsConfig { get; private set; }
     }
 
     public class WordListJson
@@ -252,6 +261,33 @@ namespace Cliptok
 
         [JsonProperty("patchTuesday")]
         public ulong PatchTuesday { get; private set; }
+    }
+
+    public class ReportsInteractionConfig
+    {
+        [JsonProperty("accept_warn_clean_emoji")]
+        public string AcceptWarnCleanEmoji { get; private set; }
+
+        [JsonProperty("accept_warn_emoji")]
+        public string AcceptWarnEmoji { get; private set; }
+
+        [JsonProperty("accept_no_warn_emoji")]
+        public string AcceptNoWarnEmoji { get; private set; }
+
+        [JsonProperty("reject_emoji")]
+        public string RejectEmoji { get; private set; }
+    }
+
+    public class ReportsConfig
+    {
+        [JsonProperty("pingModeration")]
+        public bool PingModeration { get; private set; }
+
+        [JsonProperty("allowUserReportModerator")]
+        public bool AllowUserReportModerator { get; private set; }
+
+        [JsonProperty("interactions")]
+        public ReportsInteractionConfig Interactions { get; private set; }
     }
 
 }

--- a/Modules/ReportTypes/Message.cs
+++ b/Modules/ReportTypes/Message.cs
@@ -1,0 +1,183 @@
+﻿using DSharpPlus.Entities;
+using Newtonsoft.Json;
+using System;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+
+namespace Cliptok.Modules
+{
+    /// <summary>
+    /// Message report type.
+    /// Store important information such as the author, content and timestamp.
+    /// </summary>
+    class MessageReportInfo : ReportInfo
+    {
+        public MessageReportInfo()
+        {
+        }
+
+        public MessageReportInfo(DiscordMessage message)
+        {
+            Message = message;
+            if (Message != null)
+            {
+                _Author = message.Author;
+                MessageContentSaved = message.Content;
+                MessageTimestampSaved = message.Timestamp;
+                MessageTimestampEditSaved = (DateTimeOffset)(message.EditedTimestamp != null ? message.EditedTimestamp : MessageTimestampSaved);
+            }
+        }
+
+        [OnSerializing()]
+        internal void WriteVolatile(StreamingContext context)
+        {
+            if (Message != null)
+            {
+                AuthorID = Message.Author.Id;
+                MessageID = Message.Id;
+                ChannelID = Message.Channel.Id;
+            }
+        }
+
+        public override async Task ReadInfo(DiscordGuild guild)
+        {
+            try
+            {
+                DiscordChannel channel = await Program.discord.GetChannelAsync(ChannelID);
+                Message = await channel.GetMessageAsync(MessageID);
+                _Author = Message.Author;
+            }
+            catch (Exception)
+            {
+                _Author = await Program.discord.GetUserAsync(AuthorID);
+            }
+        }
+
+        public override DiscordEmbedBuilder GenerateEmbed()
+        {
+            string Username = null;
+            string AvatarUrl = null;
+            if (Author != null)
+            {
+                Username = Author.Username;
+                AvatarUrl = Author.AvatarUrl;
+            }
+
+            return new DiscordEmbedBuilder()
+                   .WithAuthor(Username, ContextLink, AvatarUrl)
+                   .WithDescription(MessageContentSaved)
+                   .WithTimestamp(MessageTimestampSaved);
+        }
+
+        /// <summary>
+        /// Can report again only if the message has been edited.
+        /// </summary>
+        /// <returns></returns>
+        public override bool CanReportAfterReview()
+        {
+            if (Message != null && Message.EditedTimestamp != null)
+            {
+                // allow report if the message was modified
+                return Message.EditedTimestamp != MessageTimestampEditSaved;
+            }
+
+            return false;
+        }
+
+        public override IReportedContent GetReportedContent()
+        {
+            return new ReportedMessage(Message);
+        }
+
+        /// <summary>
+        /// The reported message.
+        /// </summary>
+        [JsonProperty("message_id")]
+        public ulong MessageID { get; set; }
+        [JsonIgnore()]
+        public DiscordMessage Message { get; set; }
+        
+        /// <summary>
+        /// The author of the message.
+        /// </summary>
+        [JsonProperty("author_id")]
+        public ulong AuthorID { get; set; }
+        [JsonIgnore()]
+        private DiscordUser _Author;
+        [JsonIgnore()]
+        public override DiscordUser Author { get { return _Author; } }
+
+        /// <summary>
+        /// The saved message content.
+        /// So that if the author ever edit/remove his message to avoid the infraction.
+        /// Bots can still have it.
+        /// </summary>
+        [JsonProperty("content")]
+        public string MessageContentSaved { get; set; }
+
+        /// <summary>
+        /// Timestamp of the message.
+        /// </summary>
+        [JsonProperty("timestamp")]
+        public DateTimeOffset MessageTimestampSaved { get; set; }
+
+        /// <summary>
+        /// Timestamp of the message.
+        /// </summary>
+        [JsonProperty("timestamp_edit")]
+        public DateTimeOffset MessageTimestampEditSaved { get; set; }
+
+        /// <summary>
+        /// The channel ID the message was posted in.
+        /// </summary>
+        [JsonProperty("channel_id")]
+        public ulong ChannelID { get; private set; }
+
+        /// <summary>
+        /// URL link to the message.
+        /// </summary>
+        [JsonIgnore()]
+        public override string ContextLink
+        {
+            get
+            {
+                return Message != null && Message.JumpLink != null ? Message.JumpLink.AbsoluteUri : null;
+            }
+        }
+
+        /// <summary>
+        /// Discord channel the message was posted in.
+        /// </summary>
+        [JsonIgnore()]
+        public override DiscordChannel Channel { get { return Message != null ? Message.Channel : null; } }
+    }
+
+    class ReportedMessage : IReportedContent
+    {
+        public ReportedMessage(DiscordMessage messageValue)
+        {
+            Message = messageValue;
+        }
+
+        /// <summary>
+        /// The content can be deleted as long as the associated message exists.
+        /// </summary>
+        public override void TryDelete()
+        {
+            if (Message != null)
+            {
+                Message.DeleteAsync();
+            }
+        }
+
+        /// <summary>
+        /// Discord message associated with the reported content.
+        /// </summary>
+        public DiscordMessage Message { get; }
+    }
+
+    partial class ReportTypes
+    {
+        static public ReportType MessageReportType = new ReportType(typeof(MessageReportInfo), "message", "Message");
+    }
+}

--- a/Modules/ReportTypes/User.cs
+++ b/Modules/ReportTypes/User.cs
@@ -1,0 +1,93 @@
+﻿using DSharpPlus.Entities;
+using Newtonsoft.Json;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+
+namespace Cliptok.Modules
+{
+    /// <summary>
+    /// User report type.
+    /// Store the author ID.
+    /// </summary>
+    class UserReportInfo : ReportInfo
+    {
+        public UserReportInfo()
+        {
+        }
+
+        public UserReportInfo(DiscordUser other)
+        {
+            _Author = other;
+            AuthorID = _Author.Id;
+        }
+
+        [OnSerializing()]
+        internal void WriteVolatile(StreamingContext context)
+        {
+            if (Author != null)
+            {
+                AuthorID = Author.Id;
+            }
+        }
+
+        /// <summary>
+        /// Can be reported multiple time.
+        /// No one knows what the user is doing outside the server.
+        /// </summary>
+        /// <returns></returns>
+        public override bool CanReportAfterReview()
+        {
+            // users can be reported multiple times
+            return true;
+        }
+
+        public override async Task ReadInfo(DiscordGuild guild)
+        {
+            _Author = await Program.discord.GetUserAsync(AuthorID);
+        }
+
+        public override DiscordEmbedBuilder GenerateEmbed()
+        {
+            string Username = null;
+            string AvatarUrl = null;
+            if (Author != null)
+            {
+                Username = Author.Username;
+                AvatarUrl = Author.AvatarUrl;
+            }
+
+            return new DiscordEmbedBuilder()
+                   .WithAuthor(Username, null, AvatarUrl);
+        }
+
+        /// <summary>
+        /// ID of the reported user.
+        /// </summary>
+        [JsonProperty("author_id")]
+        public ulong AuthorID;
+
+        [JsonIgnore()]
+        private DiscordUser _Author;
+
+        /// <summary>
+        /// The author's discord user.
+        /// </summary>
+        [JsonIgnore()]
+        public override DiscordUser Author { get { return _Author; } }
+
+        /// <summary>
+        /// Link to the user ID.
+        /// </summary>
+        public override string ContextLink { get { return $"<!@{Author.Id}>"; } }
+
+        /// <summary>
+        /// Always null.
+        /// </summary>
+        public override DiscordChannel Channel { get { return null; } }
+    }
+
+    partial class ReportTypes
+    {
+        static public ReportType UserReportType = new ReportType(typeof(UserReportInfo), "user", "User");
+    }
+}

--- a/Modules/Reports.cs
+++ b/Modules/Reports.cs
@@ -1,0 +1,1005 @@
+﻿using DSharpPlus;
+using DSharpPlus.CommandsNext;
+using DSharpPlus.CommandsNext.Attributes;
+using DSharpPlus.Entities;
+using DSharpPlus.EventArgs;
+using Newtonsoft.Json;
+using StackExchange.Redis;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Cliptok.Modules
+{
+    /// <summary>
+    /// Partial class for holding all report types.
+    /// </summary>
+    partial class ReportTypes
+    {
+        static ReportTypes() { }
+    }
+
+    /// <summary>
+    /// Exception called whenever an error occurs in any of the report command.
+    /// </summary>
+    class ReportCommandError : Exception
+    {
+        public ReportCommandError(DiscordMessageBuilder builder)
+        {
+            Builder = builder;
+        }
+
+        public ReportCommandError(string content)
+        {
+            Builder = new DiscordMessageBuilder().WithContent(content);
+        }
+
+        public DiscordMessageBuilder Builder { get; }
+    }
+
+    /// <summary>
+    /// Used to interact with buttons on the generated report message.
+    /// Discord has support for Components through their API, but unfortunately DSharpPlus doesn't provide that.
+    /// </summary>
+    class ReportInteraction
+    {
+        /// <summary>
+        /// Initialize the report interaction.
+        /// </summary>
+        /// <param name="emojiNameValue">Name of the emoji to use for the interaction.</param>
+        /// <param name="actionNameValue">Name of the action that will be executed.</param>
+        /// <param name="interaction">Action to execute (delegate).</param>
+        public ReportInteraction(string emojiNameValue, string actionNameValue, InteractDelegate interaction)
+        {
+            EmojiName = emojiNameValue;
+            ActionName = actionNameValue;
+            Interact = interaction;
+        }
+
+        /// <summary>
+        /// Initialize the interaction's emoji.
+        /// </summary>
+        /// <param name="client">Discord client to use.</param>
+        public void InitEmoji(DiscordClient client)
+        {
+            Emoji = DiscordEmoji.FromName(client, EmojiName);
+        }
+
+        /// <summary>
+        /// Name of the emoji.
+        /// </summary>
+        public string EmojiName { get; }
+
+        /// <summary>
+        /// Discord emoji.
+        /// </summary>
+        public DiscordEmoji Emoji { get; private set; }
+
+        /// <summary>
+        /// Name of the action.
+        /// </summary>
+        public string ActionName { get; }
+
+        public delegate void InteractDelegate(ReportObject report, DiscordUser user);
+        /// <summary>
+        /// Called on report interaction.
+        /// </summary>
+        public InteractDelegate Interact { get; }
+    }
+
+    /// <summary>
+    /// The report module used to rapidly report a message, and process it afterwards.
+    /// For possible report types, check the *ReportTypes* folder.
+    /// </summary>
+    /// <remarks>
+    /// Flagged content are stored in the "reports_users_{report type}" key, each content ID point to a report ID.
+    /// Pending reports are stored in the "reports_pending" key. Pending reports are sent for review to the #pending-reports channel
+    /// Reviewed reports are stored in the "reports_reviewed" key. Reviewed reports are sent to #reviewed-reports channel (and their pending report deleted of course).
+    /// 
+    /// There is a *reports_pending* key so that if the bot restarts it will only process pending reports
+    /// better than having to iterate through all reports to check for pending reports.
+    ///
+    /// The point of this module:
+    /// To gain the time of both the user and moderators. This should really avoid wasting time with mod mail.
+    /// With mod mail, it is like:
+    /// 1. User sends a DM to mod mail to report something (sometimes without a link)
+    /// 2. A moderator reads the mail from the mod mail channel
+    /// 3. Once the moderator read the mail, the moderator switches to the appropriate channel
+    /// 4. The moderator type the warn command against the reported user.
+    /// 5. Then it goes back to mod mail and notify the user about the report.
+    /// 6. Finally, the moderator closes the mail.
+    /// Everything is done through commands!
+    /// 
+    /// With this module, it makes everything simpler.
+    /// 1. The user will just type a single command for reporting a message.
+    /// 2. A generated report message is then sent to the #pending-reports channel => A moderator will just have to click on one of the proposed reactions to take appropriate actions.
+    /// 3. Users who reported the message are then notified, simple as that.
+    /// </remarks>
+    /// <seealso cref="ReportTypes"/>
+    class Reports : BaseCommandModule
+    {
+        static Reports()
+        {
+            // have to do that in order to force static initialization of ReportTypes
+            new ReportTypes();
+        }
+
+        public Reports()
+        {
+            ReportsInteractionConfig config = Program.cfgjson.reportsConfig.Interactions;
+
+            reportInteractions = new List<ReportInteraction>();
+            reportInteractions.Add(new ReportInteraction(config.AcceptWarnCleanEmoji, "Accept, warn and clean", ReportAcceptWarnClean));
+            reportInteractions.Add(new ReportInteraction(config.AcceptWarnEmoji, "Accept and warn", ReportAcceptWarn));
+            reportInteractions.Add(new ReportInteraction(config.AcceptNoWarnEmoji, "Accept without warning", ReportAcceptNoWarn));
+            reportInteractions.Add(new ReportInteraction(config.RejectEmoji, "Reject", ReportReject));
+
+            reportDatabase = new ReportDatabase(Program.db);
+
+            if (Program.discord.Guilds.Count <= 0 || Program.discord.Guilds[0].IsUnavailable)
+            {
+                Program.discord.GuildAvailable += OnGuildAvailable;
+            }
+            else
+            {
+                _ = Init();
+            }
+        }
+
+        /// <summary>
+        /// Asynchronous function called by the class constructor
+        /// so, channels, reports, etc can be initialized.
+        /// </summary>
+        private async Task OnGuildAvailable(DiscordClient client, GuildCreateEventArgs e)
+        {
+            Program.discord.GuildAvailable -= OnGuildAvailable;
+
+            await Init();
+        }
+
+        private async Task Init()
+        {
+
+            // initialize all interactions
+            foreach (ReportInteraction interaction in reportInteractions)
+            {
+                interaction.InitEmoji(Program.discord);
+            }
+
+            // initialize channels
+            pendingReportsChannel = await Program.discord.GetChannelAsync(Program.cfgjson.PendingReportsChannel);
+            reviewedReportsChannel = await Program.discord.GetChannelAsync(Program.cfgjson.ReviewedReportsChannel);
+            defaultChannel = await Program.discord.GetChannelAsync(Program.cfgjson.HomeChannel);
+
+            // monitor reaction and deletion event
+            Program.discord.MessageReactionAdded += OnMessageReactionAdded;
+            Program.discord.MessageDeleted += OnMessageDeleted;
+
+            // gather all pending reports
+            HashEntry[] entries = Program.db.HashGetAll("reports_pending");
+            foreach(HashEntry entry in entries)
+            {
+                ReportObject report = await DeserializeReportObject(entry.Value);
+                if (report.ReportHandle != null)
+                {
+                    // handle the report immediately
+                    HandleReaction(Program.discord, report);
+                }
+                else
+                {
+                    // it looks like the generated report message was deleted
+                    // so create a new one
+                    await CreateReportMessageWithInteraction(report, pendingReportsChannel);
+                    _ = SetReportObjectPending(report);
+                }
+            }
+        }
+
+        public async Task<bool> IsUserReviewer(CommandContext ctx, DiscordUser user)
+        {
+            // so here we have to check if the user being reported is a moderator
+            DiscordMember member = await ctx.Guild.GetMemberAsync(user.Id);
+            return IsUserReviewer(member);
+        }
+
+        public bool IsUserReviewer(DiscordMember member)
+        {
+            // assume that the member is a reviewer if he has access to reports channel
+            return member.PermissionsIn(pendingReportsChannel).HasPermission(Permissions.AccessChannels);
+        }
+
+        /// <summary>
+        /// Checks if the context user can make a report against the target user.
+        /// </summary>
+        public async Task CheckReport(CommandContext ctx, DiscordUser targetUser)
+        {
+#if DEBUG
+            // small debug cheat, useful if you have no friends
+            return;
+#endif
+
+            if (targetUser == ctx.Message.Author)
+            {
+                // prevent the user from reporting himself (attempt at trolling)
+                throw new ReportCommandError("You cannot report yourself.");
+            }
+
+            if (targetUser == ctx.Client.CurrentUser)
+            {
+                throw new ReportCommandError("The bot cannot be reported, he never says anything bad.");
+            }
+
+            if (!Program.cfgjson.reportsConfig.AllowUserReportModerator)
+            {
+                // so here we have to check if the user being reported is a moderator
+                if (await IsUserReviewer(ctx, targetUser))
+                {
+                    // assume that if the reported being reported has access to reports channel
+                    // then it's a moderator
+                    throw new ReportCommandError($"Can't report <@!{targetUser.Id}>.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Generic function for creating and modifying reports.
+        /// </summary>
+        /// <param name="reportType">Type of the report to use.</param>
+        /// <param name="ID">The content ID.</param>
+        /// <param name="reason">Reason to give for the report.</param>
+        /// <param name="createReport">Delegate called to create the specific report.</param>
+        /// <returns></returns>
+        private async Task<ReportObject> GenericManageReport(CommandContext ctx, string reportType, ulong ID, string reason, Func<ReportInfo> createReport)
+        {
+            ulong reportID = reportDatabase.GetOrSetReportFromContentID(ID, reportType);
+
+            ReportObject report = await GetReviewedReportObject(reportID);
+            if (report != null)
+            {
+                if (!report.MessageData.CanReportAfterReview())
+                {
+                    // already reviewed/moderated
+                    throw new ReportCommandError(GenerateReviewedMessage(report));
+                }
+                else
+                {
+                    // start over with a new report
+                    reportID = reportDatabase.RecreateNewReportFromContentID(ID, reportType);
+                    report = new ReportObject(reportID, ctx.Guild, createReport(), reason);
+                }
+            }
+            else
+            {
+                // the report wasn't reviewed but check if there is a pending report
+                report = await GetPendingReportObject(reportID);
+                if (report == null)
+                {
+                    // create a brand new report
+                    report = new ReportObject(reportID, ctx.Guild, createReport(), reason);
+                }
+                else if (report.Signalers.Exists(x => x == ctx.Member))
+                {
+                    // already reported
+                    throw new ReportCommandError(GenerateAlreadyReportObject(report));
+                }
+            }
+
+            // add the user to the report
+            report.Signalers.Add(ctx.Member);
+
+            if (report.ReportHandle == null)
+            {
+                // create a message in the log channel about the report
+                await CreateReportMessageWithInteraction(report, pendingReportsChannel);
+            }
+            else
+            {
+                // modify, will automatically add new users
+                await ModifyReportMessage(report);
+            }
+
+            // add the new report
+            _ = SetReportObjectPending(report);
+
+            // notify the user about the report
+            await ctx.Member.SendMessageAsync(GenerateReportObject(report));
+
+            return report;
+        }
+
+        [Command("report")]
+        [Description("Reports a message to the moderation team."), HomeServer]
+        public async Task ReportCommand(
+            CommandContext ctx,
+            [Description("The message to report. Use *Copy link* to get the message link. *Copy ID* works as long as the command in executed in the same channel as the message to be reported.")] DiscordMessage message,
+            [Description("The reason for the report. If you want to report multiple messages, don't use this parameter, make a new report instead"), RemainingText] string reason = ""
+        )
+        {
+            // delete the callee message to avoid others from judging the signalman
+            _ = ctx.Message.DeleteAsync();
+
+            if (message.Channel.Guild.Id != pendingReportsChannel.Guild.Id)
+            {
+                _ = ctx.Member.SendMessageAsync("Can't report from a different server.");
+                return;
+            }
+
+            try
+            {
+                await CheckReport(ctx, message.Author);
+                await GenericManageReport(ctx, "message", message.Id, reason, () => new MessageReportInfo(message));
+            }
+            catch(ReportCommandError e)
+            {
+                _ = ctx.Member.SendMessageAsync(e.Builder);
+                return;
+            }
+        }
+
+        [Command("report_u")]
+        [Description("Reports user to the moderation team. Make sure to give a valid reason. For example if the user is sending scams, spamming DMs, you can use this command."), HomeServer]
+        public async Task ReportUserCommand(
+            CommandContext ctx,
+            [Description("The user to report (must be present in the server).")] DiscordUser user,
+            [Description("The reason for the user report."), RemainingText] string reason = ""
+        )
+        {
+            _ = ctx.Message.DeleteAsync();
+
+            try
+            {
+                // make sure that the user to report is in the same server as the context user
+                await ctx.Guild.GetMemberAsync(user.Id);
+            }
+            catch(Exception)
+            {
+                _ = ctx.Member.SendMessageAsync("The specified user is not present in the server you want to report on.");
+                return;
+            }
+
+            try
+            {
+                await CheckReport(ctx, user);
+                await GenericManageReport(ctx, "user", user.Id, reason, () => new UserReportInfo(user));
+            }
+            catch (ReportCommandError e)
+            {
+                _ = ctx.Member.SendMessageAsync(e.Builder);
+                return;
+            }
+        }
+
+        [Command("reportf")]
+        [Description("Fix a pending report.")]
+        private async Task FixReport(
+            CommandContext ctx,
+            [Description("The report ID to fix (number), must not be reviewed.")] ulong reportID,
+            [Description("New reason to specify.")] string newReason = ""
+            )
+        {
+            _ = ctx.Message.DeleteAsync();
+
+            ReportObject report = await GetPendingReportObject(reportID);
+            if (report == null)
+            {
+                report = await GetReviewedReportObject(reportID);
+                if (report == null)
+                {
+                    _ = ctx.Member.SendMessageAsync($"The report #{reportID} doesn't exist.");
+                }
+                else
+                {
+                    _ = ctx.Member.SendMessageAsync($"The report #{reportID} was already reviewed.");
+                }
+                return;
+            }
+
+            if (ctx.Member != report.ReportOwner && !IsUserReviewer(ctx.Member))
+            {
+                // don't let anyone to edit a report, except their author and moderators
+                _ = ctx.Member.SendMessageAsync($"You must be the owner of the report (#{reportID}), or a moderator to be able to make changes.");
+                return;
+            }
+
+            // set the new reason and store the report
+            report.Reason = newReason;
+            _ = SetReportObjectPending(report);
+
+            // modify the generated report message as well
+            _ = ModifyReportMessage(report);
+
+            // send the edited report to the author
+            // NOTE: should all signalers be notified as well?
+            if (ctx.Member == report.ReportOwner)
+            {
+                await ctx.Member.SendMessageAsync(GenerateReportFixedObject(report));
+            }
+        }
+
+        [Command("reports")]
+        [Description("Get your report stats.")]
+        private async Task GetMyReports(CommandContext ctx)
+        {
+            _ = ctx.Message.DeleteAsync();
+
+            ulong numValidated = await reportDatabase.GetUserReportCount(ctx.User.Id, ReportStatus.Validated);
+            ulong numRejected = await reportDatabase.GetUserReportCount(ctx.User.Id, ReportStatus.Rejected);
+            ulong numTotal = numValidated + numRejected;
+
+
+            _ = ctx.Member.SendMessageAsync(
+                    $"Validated reports: {numValidated}\n"
+                    + $"Rejected reports: {numRejected}"
+                    + $"Total reports: {numTotal}\n"
+                );
+        }
+
+        /// <summary>
+        /// Return a report object from ID (pending).
+        /// </summary>
+        /// <param name="reportID">ID to check.</param>
+        /// <returns>Report object.</returns>
+        private async Task<ReportObject> GetPendingReportObject(ulong reportID)
+        {
+            string jsonReport = reportDatabase.GetPendingReport(reportID);
+            // sanity check
+            if (jsonReport != RedisValue.Null)
+            {
+                return await DeserializeReportObject(jsonReport);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Return a report object from ID (reviewed).
+        /// </summary>
+        /// <param name="reportID">ID to check.</param>
+        /// <returns>Report object.</returns>
+        private async Task<ReportObject> GetReviewedReportObject(ulong reportID)
+        {
+            string jsonReport = reportDatabase.GetReviewedReport(reportID);
+            if (jsonReport != null)
+            {
+                // report has already been reviewed but return it
+                return await DeserializeReportObject(jsonReport);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Deserialize a report object from JSON data.
+        /// </summary>
+        /// <param name="jsonReport">JSON data to deserialize.</param>
+        /// <returns>Report object.</returns>
+        private async Task<ReportObject> DeserializeReportObject(string jsonReport)
+        {
+            ReportObject message = JsonConvert.DeserializeObject<ReportObject>(jsonReport);
+            await message.ReadVolatile();
+
+            return message;
+        }
+
+        /// <summary>
+        /// Add a report to all users.
+        /// </summary>
+        /// <param name="report">Report to add.</param>
+        /// <param name="status">Where to store the report.</param>
+        private async Task AddReportToUsers(ReportObject report, ReportStatus status)
+        {
+            foreach (DiscordMember signaler in report.Signalers)
+            {
+                await reportDatabase.AddReportToUser(signaler.Id, status);
+            }
+        }
+
+        /// <summary>
+        /// Store the report in the pending list.
+        /// </summary>
+        /// <param name="report">Report to store.</param>
+        private async Task SetReportObjectPending(ReportObject report)
+        {
+            await reportDatabase.SetReportPending(report.Id, JsonConvert.SerializeObject(report));
+        }
+
+        /// <summary>
+        /// Store the report in the reviewed list.
+        /// </summary>
+        /// <param name="report">Report to store.</param>
+        private async Task SetReportObjectReviewed(ReportObject report, DiscordUser moderatedBy, ReportStatus status)
+        {
+            report.Status = status;
+            report.HandledBy = moderatedBy;
+            _ = report.ReportHandle.DeleteAsync();
+
+            // tell about the report
+            _ = CreateReportMessage(report, reviewedReportsChannel);
+
+            // report has been reviewed to move it appropriately
+            await reportDatabase.SetReportReviewed(report.Id, JsonConvert.SerializeObject(report));
+
+            _ = AddReportToUsers(report, status);
+        }
+
+        /// <summary>
+        /// Return the first moderator in user list.
+        /// </summary>
+        /// <param name="client">Discord client.</param>
+        /// <param name="users">User list.</param>
+        /// <returns></returns>
+        private DiscordUser GetModeratorFromUsers(DiscordClient client, IReadOnlyList<DiscordUser> users)
+        {
+            foreach(DiscordUser user in users)
+            {
+                if (user != client.CurrentUser)
+                {
+                    return user;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Process reactions from given report.
+        /// </summary>
+        /// <param name="Client">Discord client.</param>
+        /// <param name="report">Report to process.</param>
+        private async void HandleReaction(DiscordClient Client, ReportObject report)
+        {
+            ReportInteraction bestInteraction = null;
+            int highestCount = 0;
+            int smallestCount = report.ReportHandle.Reactions[0].Count;
+
+            foreach (DiscordReaction reaction in report.ReportHandle.Reactions)
+            {
+                ReportInteraction interaction = GetInteraction(reaction.Emoji);
+                if (interaction != null)
+                {
+                    if (reaction.Count > highestCount)
+                    {
+                        bestInteraction = interaction;
+                        highestCount = reaction.Count;
+                    }
+                    else if (reaction.Count < smallestCount)
+                    {
+                        smallestCount = reaction.Count;
+                    }
+                }
+            }
+
+            if (bestInteraction != null && highestCount != smallestCount)
+            {
+                IReadOnlyList<DiscordUser> acceptedUsers = await report.ReportHandle.GetReactionsAsync(bestInteraction.Emoji);
+                DiscordUser mod = GetModeratorFromUsers(Client, acceptedUsers);
+                bestInteraction.Interact(report, mod);
+            }
+        }
+
+        /// <summary>
+        /// Return the report object by the generated discord message.
+        /// </summary>
+        /// <param name="message">Generated discord message.</param>
+        /// <returns>The report object.</returns>
+        private async Task<ReportObject> GetPendingReportFromMessage(DiscordMessage message)
+        {
+            if (message.Embeds != null && message.Embeds.Count() > 0)
+            {
+                // first embed contains report info
+                DiscordEmbed embed = message.Embeds[0];
+                DiscordEmbedField field = embed.Fields.Single(f => f.Name == "Report ID");
+                if (field != null)
+                {
+                    ulong reportID = Convert.ToUInt64(field.Value);
+                    return await GetPendingReportObject(reportID);
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Return an interaction by discord emoji.
+        /// </summary>
+        /// <param name="emoji">Discord emoji.</param>
+        /// <returns>Interaction.</returns>
+        private ReportInteraction GetInteraction(DiscordEmoji emoji)
+        {
+            return reportInteractions.Find(x => x.Emoji == emoji);
+        }
+
+        /// <summary>
+        /// Event for monitoring reports interaction through reactions.
+        /// </summary>
+        private async Task OnMessageReactionAdded(DiscordClient client, MessageReactionAddEventArgs e)
+        {
+            if (e.Channel != pendingReportsChannel)
+            {
+                // only monitor messages in the report channel
+                return;
+            }
+
+            if (e.User == client.CurrentUser)
+            {
+                // ignore reactions from self
+                return;
+            }
+
+            DiscordMessage message = e.Message;
+            if (message.Author == null)
+            {
+                // no idea why the author is null sometimes
+                // have to fetch the message again
+                message = await e.Channel.GetMessageAsync(e.Message.Id);
+            }
+
+            if (message.Author != client.CurrentUser)
+            {
+                // only monitor messages in the report channel
+                return;
+            }
+
+            ReportInteraction interaction = GetInteraction(e.Emoji);
+            if (interaction != null)
+            {
+                ReportObject report = await GetPendingReportFromMessage(message);
+                if (report != null)
+                {
+                    // this report is pending so accept emojis
+                    interaction.Interact(report, e.User);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Regenerate a report message in the report channels if the message was deleted.
+        /// Otherwise the report would be awaited in the void.
+        /// </summary>
+        private async Task OnMessageDeleted(DiscordClient client, MessageDeleteEventArgs e)
+        {
+            if (e.Channel != pendingReportsChannel || e.Message.Author != client.CurrentUser)
+            {
+                // only monitor messages in the report channel
+                return;
+            }
+
+            ReportObject report = await GetPendingReportFromMessage(e.Message);
+            if (report != null)
+            {
+                // recreate the message if it was deleted
+                await CreateReportMessageWithInteraction(report, pendingReportsChannel);
+                _ = SetReportObjectPending(report);
+            }
+        }
+
+        /// <summary>
+        /// Create a report message with reactions.
+        /// </summary>
+        private async Task CreateReportMessage(ReportObject report, DiscordChannel channel)
+        {
+            if (channel != null)
+            {
+                report.ReportHandle = await channel.SendMessageAsync(GenerateReportMessage(report));
+            }
+        }
+
+        /// <summary>
+        /// Create a report message with reactions.
+        /// </summary>
+        private async Task CreateReportMessageWithInteraction(ReportObject report, DiscordChannel channel)
+        {
+            await CreateReportMessage(report, channel);
+            // create reactions for interaction
+            _ = CreateReportInteractions(report);
+        }
+
+        /// <summary>
+        /// Modify an existing report message by report object.
+        /// </summary>
+        /// <param name="report">Report object to modify the message from.</param>
+        private async Task ModifyReportMessage(ReportObject report)
+        {
+            report.ReportHandle = await report.ReportHandle.ModifyAsync(GenerateReportMessage(report));
+        }
+
+        /// <summary>
+        /// Create interaction emojis for the report object's generated message.
+        /// </summary>
+        /// <param name="report">The report object.</param>
+        private async Task CreateReportInteractions(ReportObject report)
+        {
+            // create reactions for interaction
+            foreach (ReportInteraction interaction in reportInteractions)
+            {
+                await report.ReportHandle.CreateReactionAsync(interaction.Emoji);
+            }
+        }
+
+        /// <summary>
+        /// Call to validate a specific report.
+        /// </summary>
+        /// <param name="report">Report to validate.</param>
+        /// <param name="moderatedBy">The moderator who reviewed the report.</param>
+        private void ValidateReport(ReportObject report, DiscordUser moderatedBy)
+        {
+            _ = SetReportObjectReviewed(report, moderatedBy, ReportStatus.Validated);
+
+            // notify all signalers about the report
+            report.NotifyUserReport(NotifyUserReportAccepted);
+        }
+
+        private void WarnUserFromReport(ReportObject report, DiscordUser moderatedBy)
+        {
+            DiscordChannel channel = report.MessageData.Channel;
+            if (channel == null)
+            {
+                channel = defaultChannel;
+            }
+
+            // give the reported user a warning
+            _ = Warnings.GiveWarningAsync(
+                report.MessageData.Author,
+                moderatedBy,
+                report.Reason,
+                report.MessageData.ContextLink,
+                report.MessageData.Channel
+            );
+        }
+
+        /// <summary>
+        /// Called to accept, validate a specific report, warn the reported user and delete his message.
+        /// </summary>
+        /// <param name="report">The report to validate.</param>
+        /// <param name="moderatedBy">The moderator who reviewed the report.</param>
+        private void ReportAcceptWarnClean(ReportObject report, DiscordUser moderatedBy)
+        {
+            report.ActionTaken = "Warn and clean";
+
+            ValidateReport(report, moderatedBy);
+
+            // give the reported user a warning
+            WarnUserFromReport(report, moderatedBy);
+
+            // delete his message
+            IReportedContent content = report.MessageData.GetReportedContent();
+            if (content != null)
+            {
+                // we've got a content so try to delete it
+                content.TryDelete();
+            }
+        }
+
+        /// <summary>
+        /// Called to accept, validate a specific report, and warn the reported user.
+        /// </summary>
+        /// <param name="report">The report to validate.</param>
+        /// <param name="moderatedBy">The moderator who reviewed the report.</param>
+        private void ReportAcceptWarn(ReportObject report, DiscordUser moderatedBy)
+        {
+            report.ActionTaken = "Warn";
+
+            ValidateReport(report, moderatedBy);
+
+            // give the reported user a warning
+            WarnUserFromReport(report, moderatedBy);
+
+            // should the message be deleted?
+            // maybe a third button to accept & delete?
+        }
+
+        /// <summary>
+        /// Called to accept, validate a specific report, without warning the reported user.
+        /// </summary>
+        /// <param name="report">The report to validate.</param>
+        /// <param name="moderatedBy">The moderator who reviewed the report.</param>
+        private void ReportAcceptNoWarn(ReportObject report, DiscordUser moderatedBy)
+        {
+            report.ActionTaken = "No warn";
+
+            ValidateReport(report, moderatedBy);
+        }
+
+        /// <summary>
+        /// Call to reject a specific report.
+        /// </summary>
+        /// <param name="report">Report to validate.</param>
+        /// <param name="moderatedBy">The moderator who reviewed the report.</param>
+        private void ReportReject(ReportObject report, DiscordUser moderatedBy)
+        {
+            _ = SetReportObjectReviewed(report, moderatedBy, ReportStatus.Rejected);
+
+            // notify all signalers about the report
+            report.NotifyUserReport(NotifyUserReportRejected);
+        }
+
+        /// <summary>
+        /// Called to notify an user about the report.
+        /// </summary>
+        /// <param name="report">The report.</param>
+        /// <param name="member">User to notify.</param>
+        private void NotifyUserReportAccepted(ReportObject report, DiscordMember member)
+        {
+            // notify the user that he is making the community a better place for people
+            member.SendMessageAsync(GenerateReportValidatedMessage(report));
+        }
+
+        /// <summary>
+        /// Called to notify an user about the report.
+        /// </summary>
+        /// <param name="report">The report.</param>
+        /// <param name="member">User to notify.</param>
+        private void NotifyUserReportRejected(ReportObject report, DiscordMember member)
+        {
+            member.SendMessageAsync(GenerateReportRejectedMessage(report));
+        }
+
+        /// <summary>
+        /// Generate an embed based on the message.
+        /// </summary>
+        /// <param name="message">Message to generate embed from.</param>
+        /// <param name="color">Embed color.</param>
+        /// <returns>Built embeded message.</returns>
+        public DiscordEmbedBuilder GenerateEmbedMessage(ReportObject report, DiscordColor color)
+        {
+            return report.MessageData.GenerateEmbed()
+                   .WithColor(color)
+                   .WithTitle($"Report #{report.Id:00000}")
+                   .AddField("Type", report.MessageData.Type.Description)
+                   .AddField("Reason", report.Reason);
+        }
+
+        /// <summary>
+        /// Generate a report message for moderators.
+        /// </summary>
+        /// <param name="reported">The reported message information.</param>
+        /// <returns>Built message</returns>
+        public DiscordMessageBuilder GenerateReportMessage(ReportObject reported)
+        {
+            string reportedBy = "";
+            foreach(DiscordMember signaler in reported.Signalers)
+            {
+                reportedBy += $"<@!{signaler.Id}> ";
+            }
+
+            string actions = "";
+            foreach(ReportInteraction interaction in reportInteractions)
+            {
+                actions += $"{interaction.Emoji.ToString()} {interaction.ActionName}\n";
+            }
+
+            DiscordEmbedBuilder embededMessage = GenerateEmbedMessage(reported, new DiscordColor(255, 0, 255))
+                .AddField("Report ID", reported.Id.ToString("D5"))
+                .AddField("Status", reported.Status.ToString())
+                .AddField("Reported by", reportedBy);
+
+            if (reported.Status != ReportStatus.Pending)
+            {
+                // was reviewed
+                if (reported.HandledBy != null)
+                {
+                    embededMessage = embededMessage.AddField("Reviewed by", $"<@!{reported.HandledBy.Id}>");
+                }
+
+                if (reported.ActionTaken != null && reported.ActionTaken.Length > 0)
+                {
+                    embededMessage = embededMessage.AddField("Action taken", reported.ActionTaken);
+                }
+            }
+            else
+            {
+                embededMessage.AddField("Actions", actions);
+
+                if (Program.cfgjson.reportsConfig.PingModeration)
+                {
+                    // ping moderator and admin roles
+                    return new DiscordMessageBuilder()
+                        .WithEmbed(embededMessage)
+                        .WithContent("@here");
+                }
+            }
+
+            return new DiscordMessageBuilder()
+                    .WithEmbed(embededMessage);
+        }
+
+        /// <summary>
+        /// Generate a message for thanking the user about his report.
+        /// </summary>
+        /// <param name="reported">The reported message information.</param>
+        /// <returns>Built message</returns>
+        public DiscordMessageBuilder GenerateReportObject(ReportObject reported)
+        {
+            return new DiscordMessageBuilder()
+                   .WithContent($"Thanks for reporting! I will let you know after a moderator processed your report. Your report:")
+                   .WithEmbed(GenerateEmbedMessage(reported, new DiscordColor(255, 0, 255)));
+        }
+
+        /// <summary>
+        /// Generate a message for thanking the user about his report.
+        /// </summary>
+        /// <param name="reported">The reported message information.</param>
+        /// <returns>Built message</returns>
+        public DiscordMessageBuilder GenerateReportFixedObject(ReportObject reported)
+        {
+            return new DiscordMessageBuilder()
+                   .WithContent($"You edited your report (ID #{reported.Id}). Your new report:")
+                   .WithEmbed(GenerateEmbedMessage(reported, new DiscordColor(255, 0, 255)));
+        }
+
+        /// <summary>
+        /// Generate a message telling the user he already reported.
+        /// </summary>
+        /// <param name="reported">The reported message information.</param>
+        /// <returns>Built message</returns>
+        public DiscordMessageBuilder GenerateAlreadyReportObject(ReportObject reported)
+        {
+            return new DiscordMessageBuilder()
+                   .WithContent($"You already reported content. Please wait for the moderation team to review your report. Your report:")
+                   .WithEmbed(GenerateEmbedMessage(reported, new DiscordColor(255, 0, 255)));
+        }
+
+        /// <summary>
+        /// Generate telling the reported message was already reviewed by a moderator.
+        /// </summary>
+        /// <param name="reported">The reported message information.</param>
+        /// <returns>Built message</returns>
+        public DiscordMessageBuilder GenerateReviewedMessage(ReportObject reported)
+        {
+            return new DiscordMessageBuilder()
+                   .WithContent("The message you tried to report was already reviewed by a moderator:")
+                   .WithEmbed(GenerateEmbedMessage(reported, new DiscordColor(255, 0, 255)));
+        }
+
+        /// <summary>
+        /// Generate a message to tell that the report was validated.
+        /// </summary>
+        /// <param name="reported">The reported message information.</param>
+        /// <returns>Built message</returns>
+        public DiscordMessageBuilder GenerateReportValidatedMessage(ReportObject reported)
+        {
+            return new DiscordMessageBuilder()
+                   .WithContent("The moderation team has reviewed your report and took appropriate actions. The reported content was found to be against the server rules, we thank you for your report. Your report:")
+                   .WithEmbed(GenerateEmbedMessage(reported, new DiscordColor(255, 0, 0)));
+        }
+
+        /// <summary>
+        /// Generate a message to tell that the report was rejected.
+        /// </summary>
+        /// <param name="reported">The reported message information.</param>
+        /// <returns>Built message</returns>
+        public DiscordMessageBuilder GenerateReportRejectedMessage(ReportObject reported)
+        {
+            return new DiscordMessageBuilder()
+                   .WithContent(
+                        "Following your report, the moderation team has estimated that the message is not against the server rules.\n"
+                        + "If you think this is an error, please contact a moderator through the moderation mail. Your report:"
+                    )
+                   .WithEmbed(GenerateEmbedMessage(reported, new DiscordColor(0, 255, 0)));
+        }
+
+        /// <summary>
+        /// Channel for all reports that were reviewed.
+        /// </summary>
+        public DiscordChannel reviewedReportsChannel { get; private set; }
+        /// <summary>
+        /// Channel for all reports that are currently pending.
+        /// </summary>
+        public DiscordChannel pendingReportsChannel { get; private set; }
+        /// <summary>
+        /// Default channel to use, currently only used for warnings.
+        /// </summary>
+        public DiscordChannel defaultChannel { get; private set; }
+
+        /// <summary>
+        /// List of valid report interactions.
+        /// </summary>
+        private List<ReportInteraction> reportInteractions;
+
+        /// <summary>
+        /// Report database.
+        /// </summary>
+        private ReportDatabase reportDatabase;
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -299,7 +299,7 @@ namespace Cliptok
             commands = discord.UseCommandsNext(new CommandsNextConfiguration
             {
                 StringPrefixes = cfgjson.Core.Prefixes
-            }); ;
+            });
 
             commands.RegisterCommands<Warnings>();
             commands.RegisterCommands<MuteCmds>();
@@ -307,6 +307,7 @@ namespace Cliptok
             commands.RegisterCommands<ModCmds>();
             commands.RegisterCommands<Lockdown>();
             commands.RegisterCommands<Bans>();
+            commands.RegisterCommands<Reports>();
 
             await discord.ConnectAsync();
 

--- a/ReportDatabase.cs
+++ b/ReportDatabase.cs
@@ -1,0 +1,195 @@
+﻿using StackExchange.Redis;
+using System.Threading.Tasks;
+
+namespace Cliptok
+{
+    class ReportDatabase
+    {
+        public ReportDatabase(IDatabase database)
+        {
+            db = database;
+        }
+
+        /// <summary>
+        /// Get or create a report from a generic content ID.
+        /// </summary>
+        /// <param name="genericID">Content ID.</param>
+        /// <param name="key">Report key (the report type actually).</param>
+        /// <returns></returns>
+        public ulong GetOrSetReportFromContentID(ulong genericID, string key)
+        {
+            RedisValue reportVal = GetReportFromContentID(genericID, key);
+            if (reportVal != RedisValue.Null)
+            {
+                return (ulong)reportVal;
+            }
+
+            return CreateNewReportFromContentID(genericID, key);
+        }
+
+        /// <summary>
+        /// Recreate a new report from a content ID, deleting the previous one.
+        /// </summary>
+        /// <param name="genericID">Content ID.</param>
+        /// <param name="key">Report key (the report type actually).</param>
+        /// <returns></returns>
+        public ulong RecreateNewReportFromContentID(ulong genericID, string key)
+        {
+            DeleteReportHashFromContentID(genericID, key);
+            return CreateNewReportFromContentID(genericID, key);
+        }
+
+        /// <summary>
+        /// Delete report from content ID.
+        /// </summary>
+        /// <param name="genericID">Content ID.</param>
+        /// <param name="key">Report key (the report type actually).</param>
+        public void DeleteReportHashFromContentID(ulong genericID, string key)
+        {
+            RedisValue reportVal = GetReportFromContentID(genericID, key);
+            if (reportVal != RedisValue.Null)
+            {
+                db.HashDelete("reports_pending", reportVal);
+                db.HashDelete("reports_reviewed", reportVal);
+            }
+
+            db.HashDelete($"rp_{key}", genericID.ToString());
+        }
+
+        /// <summary>
+        /// Check if a report is pending.
+        /// </summary>
+        /// <param name="reportID">Report ID to check.</param>
+        /// <returns>Whether or not the report is pending.</returns>
+        public bool IsPendingReport(ulong reportID)
+        {
+            RedisValue jsonReport = db.HashGet("reports_pending", reportID);
+            return jsonReport != RedisValue.Null;
+        }
+
+        /// <summary>
+        /// Return a report object from ID (pending).
+        /// </summary>
+        /// <param name="reportID">ID to check.</param>
+        /// <returns>Report object.</returns>
+        public string GetPendingReport(ulong reportID)
+        {
+            RedisValue jsonReport = db.HashGet("reports_pending", reportID);
+            // sanity check
+            if (jsonReport != RedisValue.Null)
+            {
+                return jsonReport;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Return a report object from ID (reviewed).
+        /// </summary>
+        /// <param name="reportID">ID to check.</param>
+        /// <returns>Report object.</returns>
+        public string GetReviewedReport(ulong reportID)
+        {
+            RedisValue jsonReport = db.HashGet("reports_reviewed", reportID);
+            if (jsonReport != RedisValue.Null)
+            {
+                // report has already been reviewed but return it
+                return jsonReport;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Store the report in the pending list.
+        /// </summary>
+        /// <param name="report">Report to store.</param>
+        public async Task SetReportPending(ulong ID, string jsonString)
+        {
+            await db.HashSetAsync("reports_pending", ID, jsonString);
+        }
+
+        /// <summary>
+        /// Store the report in the reviewed list.
+        /// </summary>
+        /// <param name="report">Report to store.</param>
+        public async Task SetReportReviewed(ulong ID, string jsonString)
+        {
+            // report has been reviewed to move it appropriately
+            await db.HashSetAsync("reports_reviewed", ID, jsonString);
+            _ = db.HashDeleteAsync("reports_pending", ID);
+        }
+
+        /// <summary>
+        /// Add a report to the user.
+        /// </summary>
+        /// <param name="report">Report to add.</param>
+        /// <param name="status">Where to store the report.</param>
+        public async Task AddReportToUser(ulong userID, ReportStatus status)
+        {
+            string key = GetReportUserKey(status);
+            await Program.db.HashIncrementAsync(key, userID);
+        }
+
+        /// <summary>
+        /// Return the number of reports from this user.
+        /// </summary>
+        /// <param name="user">The user to get the count from.</param>
+        /// <param name="status">Specific report status to count.</param>
+        /// <returns></returns>
+        public async Task<ulong> GetUserReportCount(ulong userID, ReportStatus status)
+        {
+            string key = GetReportUserKey(status);
+            RedisValue value = await db.HashGetAsync(key, userID);
+            if (value != RedisValue.Null)
+            {
+                return (ulong)value;
+            }
+
+            return 0;
+        }
+
+        /// <summary>
+        /// Return user report key from report status.
+        /// </summary>
+        /// <param name="status">Report status.</param>
+        /// <returns>User key string.</returns>
+        private string GetReportUserKey(ReportStatus status)
+        {
+            return $"reports_users_{status.ToString().ToLower()}";
+        }
+
+        /// <summary>
+        /// Return a report from a content ID.
+        /// </summary>
+        /// <param name="genericID">Content ID.</param>
+        /// <param name="key">Report key (the report type actually).</param>
+        /// <returns></returns>
+        private RedisValue GetReportFromContentID(ulong genericID, string key)
+        {
+            return db.HashGet($"rp_{key}", genericID.ToString());
+        }
+
+        /// <summary>
+        /// Create a new report from a content ID.
+        /// </summary>
+        /// <param name="genericID">Content ID.</param>
+        /// <param name="key">Report key (the report type actually).</param>
+        /// <returns></returns>
+        private ulong CreateNewReportFromContentID(ulong genericID, string key)
+        {
+            ulong reportID = GenerateID();
+            db.HashSet($"rp_{key}", genericID.ToString(), reportID);
+
+            return reportID;
+        }
+
+        private ulong GenerateID()
+        {
+            return (ulong)db.StringIncrement("numReports");
+        }
+
+        private IDatabase db { get; }
+    }
+}

--- a/ReportObject.cs
+++ b/ReportObject.cs
@@ -1,0 +1,396 @@
+﻿using DSharpPlus.Entities;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+
+namespace Cliptok
+{
+    abstract class IReportedContent
+    {
+        /// <summary>
+        /// Try to delete whatever the content is.
+        /// </summary>
+        /// <returns></returns>
+        public virtual void TryDelete() { }
+    }
+
+    /// <summary>
+    /// Abstract class describing the reported content.
+    /// </summary>
+    abstract class ReportInfo
+    {
+        public ReportInfo()
+        {
+            // automatically set the type
+            Type = ReportType.GetType(this.GetType());
+        }
+
+        /// <summary>
+        /// Return whether or not the content can be reported again after review.
+        /// </summary>
+        /// <returns></returns>
+        public virtual bool CanReportAfterReview() { return false; }
+
+        /// <summary>
+        /// Return the reported content.
+        /// </summary>
+        /// <returns></returns>
+        public virtual IReportedContent GetReportedContent() { return null; }
+
+        /// <summary>
+        /// Generate an embed describing the content.
+        /// </summary>
+        /// <returns>An embed builder.</returns>
+        public abstract DiscordEmbedBuilder GenerateEmbed();
+
+        /// <summary>
+        /// Initialize fields, objects, etc, anything from their ID.
+        /// </summary>
+        /// <param name="guild">Necessary to get channels, users, etc.</param>
+        public abstract Task ReadInfo(DiscordGuild guild);
+
+
+        /// <summary>
+        /// The report type for this object
+        /// </summary>
+        [JsonIgnore()]
+        public ReportType Type { get; }
+
+        /// <summary>
+        /// Author of the message.
+        /// </summary>
+        public abstract DiscordUser Author { get; }
+
+        /// <summary>
+        /// Link to the reported thing.
+        /// </summary>
+        public abstract string ContextLink { get; }
+
+        /// <summary>
+        /// The channel of the reported message.
+        /// </summary>
+        public abstract DiscordChannel Channel { get; }
+    }
+
+    /// <summary>
+    /// Used to convert between any *ReportInfo* class and JSON, with the *type* field.
+    /// </summary>
+    public class ReportInfoConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            ReportInfo info = (ReportInfo)value;
+
+            JObject jObject = JObject.FromObject(value);
+            jObject["type"] = info.Type.Name;
+            serializer.Serialize(writer, jObject);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            // load json data
+            JObject jObject = JObject.Load(reader);
+            // get report type from object
+            ReportType reportType = ReportType.GetType(jObject.GetValue("type").ToString());
+
+            // create the specific report
+            ReportInfo newReportInfo = (ReportInfo)Activator.CreateInstance(reportType.ClassType);
+
+            // serialize the specific report
+            serializer.Populate(jObject.CreateReader(), newReportInfo);
+
+            return newReportInfo;
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType.IsSubclassOf(typeof(ReportInfo));
+        }
+    }
+
+    /// <summary>
+    /// Self-explanatory, contains info about the class to use for the report.
+    /// </summary>
+    class ReportType
+    {
+        /// <summary>
+        /// Initialize a new report type.
+        /// </summary>
+        /// <param name="typeValue">Class to use for the report type, must inherit from *ReportInfo*</param>
+        /// <param name="nameValue">Name of the type (code name).</param>
+        /// <param name="descriptionValue">Short human-readable text describing the type.</param>
+        public ReportType(Type typeValue, string nameValue, string descriptionValue)
+        {
+            Name = nameValue;
+            Description = descriptionValue;
+            ClassType = typeValue;
+            Types.Add(this);
+        }
+
+        ~ReportType()
+        {
+            Types.Remove(this);
+        }
+
+        /// <summary>
+        /// Return the report type by name.
+        /// </summary>
+        /// <param name="name">Name to get the type from.</param>
+        /// <returns></returns>
+        static public ReportType GetType(string name)
+        {
+            return Types.Find(t => t.Name == name);
+        }
+
+        /// <summary>
+        /// Return the report type by class type.
+        /// </summary>
+        /// <param name="reportType">Class type to get report from.</param>
+        /// <returns></returns>
+        static public ReportType GetType(Type reportType)
+        {
+            return Types.Find(t => t.ClassType == reportType);
+        }
+
+        /// <summary>
+        /// The class type to use for this report type.
+        /// </summary>
+        [JsonIgnore()]
+        public Type ClassType { get; }
+
+        /// <summary>
+        /// Name of the report type.
+        /// </summary>
+        [JsonProperty()]
+        public string Name { get; }
+
+        /// <summary>
+        /// The human readable description.
+        /// </summary>
+        [JsonIgnore()]
+        public string Description { get; }
+
+        /// <summary>
+        /// List of all report types.
+        /// </summary>
+        static public List<ReportType> Types { get; } = new List<ReportType>();
+    }
+
+    /// <summary>
+    /// The status of a report.
+    /// </summary>
+    enum ReportStatus
+    {
+        /// <summary>
+        /// The report is currently pending.
+        /// </summary>
+        Pending,
+        /// <summary>
+        /// The report was reviewed and validated by a moderator.
+        /// </summary>
+        Validated,
+        /// <summary>
+        /// The report was reviewed and rejected by a moderator.
+        /// </summary>
+        Rejected
+    };
+
+    /// <summary>
+    /// Stores various information about the reported message.
+    /// </summary>
+    class ReportObject
+    {
+        public ReportObject()
+        {
+            Signalers = new List<DiscordMember>();
+        }
+
+        /// <summary>
+        /// Initialize the report object.
+        /// </summary>
+        /// <param name="idValue">The report ID.</param>
+        /// <param name="guild">Discord guild that this report is on.</param>
+        /// <param name="reportInfo">Abstract report information.</param>
+        /// <param name="reasonValue">The reason given for the report.</param>
+        public ReportObject(ulong idValue, DiscordGuild guild, ReportInfo reportInfo, string reasonValue)
+        {
+            Id = idValue;
+            MessageData = reportInfo;
+            GuildID = guild.Id;
+            Signalers = new List<DiscordMember>();
+            Reason = reasonValue;
+            Status = ReportStatus.Pending;
+        }
+
+        /// <summary>
+        /// Sets IDs before serializing.
+        /// </summary>
+        [OnSerializing()]
+        internal void WriteVolatile(StreamingContext context)
+        {
+            if (ReportHandle != null)
+            {
+                ReportHandleID = ReportHandle.Id;
+                ReportChannelID = ReportHandle.Channel.Id;
+            }
+
+            if (HandledBy != null)
+            {
+                HandledByID = HandledBy.Id;
+            }
+
+            // gather members ID
+            SignalersID = new ulong[Signalers.Count];
+            ulong index = 0;
+            foreach (DiscordMember signaler in Signalers)
+            {
+                SignalersID[index++] = signaler.Id;
+            }
+        }
+
+        /// <summary>
+        /// Read and get objects from their ID.
+        /// </summary>
+        public async Task ReadVolatile()
+        {
+            // get channel and message
+            try
+            {
+                DiscordGuild guild = await Program.discord.GetGuildAsync(GuildID);
+                if (guild != null)
+                {
+                    await MessageData.ReadInfo(guild);
+                }
+
+                // gather users who reported
+                Signalers.Clear();
+                foreach (ulong signalerID in SignalersID)
+                {
+                    try
+                    {
+                        DiscordMember member = await guild.GetMemberAsync(signalerID);
+                        Signalers.Add(member);
+                    }
+                    catch (Exception)
+                    {
+                    }
+                }
+            }
+            catch (Exception)
+            {
+            }
+
+            try
+            {
+                // get the generated report message
+                DiscordChannel handleChannel = await Program.discord.GetChannelAsync(ReportChannelID);
+                if (handleChannel != null)
+                {
+                    ReportHandle = await handleChannel.GetMessageAsync(ReportHandleID);
+                }
+            }
+            catch (Exception)
+            {
+            }
+
+            try
+            {
+                HandledBy = await Program.discord.GetUserAsync(HandledByID);
+            }
+            catch (Exception)
+            {
+            }
+        }
+
+        public delegate void ReportNotifyDelegate(ReportObject report, DiscordMember member);
+        /// <summary>
+        /// Callback for all users who reported.
+        /// </summary>
+        /// <param name="callback">Callback</param>
+        public void NotifyUserReport(ReportNotifyDelegate callback)
+        {
+            // notify all users about the report
+            foreach (DiscordMember member in Signalers)
+            {
+                callback(this, member);
+            }
+        }
+
+        /// <summary>
+        /// The report ID.
+        /// </summary>
+        [JsonProperty("id")]
+        public ulong Id { get; private set; }
+
+        /// <summary>
+        /// The main guild of the report.
+        /// </summary>
+        [JsonProperty("guild_id")]
+        public ulong GuildID { get; private set; }
+
+        /// <summary>
+        /// The message information.
+        /// </summary>
+        [JsonProperty(), JsonConverter(typeof(ReportInfoConverter))]
+        public ReportInfo MessageData { get; private set; }
+
+        /// <summary>
+        /// List of users who reported the message.
+        /// </summary>
+        [JsonProperty("signalers_id")]
+        public ulong[] SignalersID { get; private set; }
+        [JsonIgnore()]
+        public List<DiscordMember> Signalers { get; }
+        [JsonIgnore()]
+        public DiscordMember ReportOwner
+        {
+            get
+            {
+                return Signalers.Count > 0 ? Signalers[0] : null;
+            }
+        }
+
+        /// <summary>
+        /// Reason given to the message.
+        /// </summary>
+        [JsonProperty("reason")]
+        public string Reason { get; set; }
+
+        /// <summary>
+        /// Handle to the message the bot created for the report.
+        /// </summary>
+        [JsonProperty("report_handle")]
+        public ulong ReportHandleID { get; set; }
+        [JsonIgnore()]
+        public DiscordMessage ReportHandle;
+
+        /// <summary>
+        /// The channel the report handle was created in.
+        /// </summary>
+        [JsonProperty("report_channel_id")]
+        public ulong ReportChannelID { get; set; }
+
+        /// <summary>
+        /// The current report status.
+        /// </summary>
+        [JsonProperty("status")]
+        public ReportStatus Status { get; set; }
+
+        /// <summary>
+        /// The current report status.
+        /// </summary>
+        [JsonProperty("handled_by_id")]
+        public ulong HandledByID { get; private set; }
+        [JsonIgnore()]
+        public DiscordUser HandledBy;
+
+        /// <summary>
+        /// The action that was taken after validation.
+        /// </summary>
+        [JsonIgnore()]
+        public string ActionTaken;
+    }
+}

--- a/config.json
+++ b/config.json
@@ -16,6 +16,8 @@
   "supportLogChannel": 843181924687806484,
   "communityTechSupportRoleID": 787033266225938472,
   "modmailUserId": 459322015044730903,
+  "pendingReportsChannel": 0,
+  "reviewedReportsChannel": 0,
   "supportRatelimitMinutes": 15,
   "appealLink": "https://msft.chat/member/#ban-appeal-process",
   "warningDaysThreshold": 30,
@@ -96,7 +98,7 @@
     "everyone.txt": {
       "wholeWord": false,
       "reason": "Attempted to ping everyone/here"
-    },
+    }
   },
   "massEmojiThreshold": 6,
   "unrestrictedEmojiChannels": [
@@ -140,5 +142,15 @@
     "544153359712649251"
   ],
   "autoDehoistCharacters": " !\"#$%&'()*+,-./:;<=>?@[\\]^_`'",
-  "secondaryAutoDehoistCharacters": "0123456789"
+  "secondaryAutoDehoistCharacters": "0123456789",
+  "reports": {
+    "pingModeration": true,
+    "allowUserReportModerator": false,
+    "interactions": {
+      "accept_warn_clean_emoji": ":red_circle:",
+      "accept_warn_emoji": ":orange_circle:",
+      "accept_no_warn_emoji": ":purple_circle:",
+      "reject_emoji": ":green_circle:"
+    }
+  }
 }


### PR DESCRIPTION
Following the issue #52, I decided implement the report feature! I think it will be a lot beneficial for everyone in the Microsoft Community (moderators & users).

## A few changes to note

### Commands

- `!report_fix` is called `!reportf` instead, and anyone can fix a report as long as they own it (or if it's a moderator).
- `!report`, `!reportf`, and `!reports` can be processed in DM as well so that no one would be able to know who reported them.
- Added `!report_u`: allows anyone to report an user from the server. This should only be used if the user is doing things outside the server, like sending malicious DMs.
- Added `!reports`: allows anyone to view their report statistics.

### Reports

There are currently 2 report types: **Message**, and **User**.

Whenever an user reports something, the bot will generate a report message in a specific channel **#reports** channel (must be accessible by mods only), configurable in _config.json_. The report is more detailed, it includes the type, reason, report ID, status, list of people who reported and the moderator who reviewed the report.
Also, to alert moderators the bot will ping **@here** for every generated pending report message in the **#reports** channel (configurable in _config.json_).

#### Interaction

Now there are currently 4 buttons, for handling the report:
- Warn and clean => if the reported content is a message, the message will be deleted. If it's an user, the user will only be warned (same as _Warn only_)
- Warn only
- No warn
- Decline report
Reactions emoji are configurable in _config.json_.

Once the report was reviewed, the generated report message is moved to the **#reviewed-reports** channel. It is better for moderators, reports are split between pending reports and reviewed reports.
"decline" is called "reject" in the code, maybe decline is more clever/satisfying to the user, not sure which word is better. Same for "accept", this one may be the most suitable word for reports.

### More new conditions

- If a moderator deletes the generated pending report message (from **#reports** channel), the bot will recreate it.
- On initialization, the bot will process pending reports. This includes checking for interactions (moderator who reacted to the generated pending report message), and checking for generated pending report messages that were deleted (will recreate them in this case).

The following conditions are applied only in non-Debug builds:
- A moderator can't be reported (configurable in _config.json_).
- The bot can't be reported.
- Users can't report themselves.

#### Reported messages

- A message that was reviewed can't be reported again, except if it was edited (prevent abuse/exploit).
- A generated report message contains the reported content at the time of the report. The report won't be edited if the original reported message is edited. This should prevent trolls from avoiding punishment if they see that they were reported.

### Notes

The report system considers users as moderator if they have access to **#reports** channels. Maybe make a list of roles that cannot be reported instead? Also, my suggestion is to avoid writing anything inside any of these **#reports** channel. It should be better to discuss about a report in another private channel instead (I've seen that there is an **#investigation** channel, could be there!).

This feature may require more testing. Also generated texts in _Modules/Reports.cs_ could be done better (I'm not a native english speaker).
The only thing I'm worried about is race-condition, but I think that the bot waits for the async command to finish, it should be good.

There is 1 issue: currently, generated report messages can't contain uploaded images. This could be fixed by replacing the reported message image with the discord link to the uploaded image.

### What has been tested

- [x] Report messages
- [x] Report users
- [x] Boost a report (one or more users reporting the same content)
- [x] Make multiple reports
- [x] Fixing a report that was reviewed
- [x] Fixing an owning report
- [x] Fixing a report as a moderator
- [ ] Fixing a report without owning it and without being a moderator
- [x] Fixing a report, and review the report
- [x] View report stats
- [x] Accept a report (warn & clean, warn, no warn)
- [x] Reject a report
- [x] Delete a generated pending report message
- [x] Shutdown the bot, delete a generated pending report message and restart the bot
- [x] Shutdown the bot, react to a generated pending report message and restart the bot
- [x] Delete/edit the original reported message, and then review the report
- [x] Review a report, then edit the reported message and report the message again
- [ ] Docker container