### PR TITLE
Update !timestamp to support multiple formats

### DIFF
--- a/Modules/ModCmds.cs
+++ b/Modules/ModCmds.cs
@@ -349,7 +349,7 @@ namespace Cliptok.Modules
         [Aliases("ts", "time")]
         [Description("Returns various timestamps for a given Discord ID/snowflake")]
         [HomeServer, RequireHomeserverPerm(ServerPermLevel.Mod)]
-        class DebugCmds : BaseCommandModule
+        class TimestampCmds : BaseCommandModule
         {
             [Command("unix")]
             [Aliases("u", "epoch")]

--- a/Modules/ModCmds.cs
+++ b/Modules/ModCmds.cs
@@ -354,7 +354,7 @@ namespace Cliptok.Modules
             [Command("unix")]
             [Aliases("u", "epoch")]
             [Description("Returns the Unix timestamp of a given Discord ID/snowflake")]
-            public async Task TimestampCmd(CommandContext ctx, [Description("The ID/snowflake to fetch the Unix timestamp for")] ulong snowflake)
+            public async Task TimestampUnixCmd(CommandContext ctx, [Description("The ID/snowflake to fetch the Unix timestamp for")] ulong snowflake)
             {
                 var msSinceEpoch = snowflake >> 22;
                 var msUnix = msSinceEpoch + 1420070400000;
@@ -364,7 +364,7 @@ namespace Cliptok.Modules
             [Command("relative")]
             [Aliases("r")]
             [Description("Returns the amount of time between now and a given Discord ID/snowflake")]
-            public async Task TimestampCmd(CommandContext ctx, [Description("The ID/snowflake to fetch the Unix timestamp for")] ulong snowflake)
+            public async Task TimestampRelativeCmd(CommandContext ctx, [Description("The ID/snowflake to fetch the Unix timestamp for")] ulong snowflake)
             {
                 var msSinceEpoch = snowflake >> 22;
                 var msUnix = msSinceEpoch + 1420070400000;
@@ -374,7 +374,7 @@ namespace Cliptok.Modules
             [Command("fulldate")]
             [Aliases("f", "datetime")]
             [Description("Returns the fully-formatted date and time of a given Discord ID/snowflake")]
-            public async Task TimestampCmd(CommandContext ctx, [Description("The ID/snowflake to fetch the Unix timestamp for")] ulong snowflake)
+            public async Task TimestampFullCmd(CommandContext ctx, [Description("The ID/snowflake to fetch the Unix timestamp for")] ulong snowflake)
             {
                 var msSinceEpoch = snowflake >> 22;
                 var msUnix = msSinceEpoch + 1420070400000;

--- a/Modules/ModCmds.cs
+++ b/Modules/ModCmds.cs
@@ -364,7 +364,7 @@ namespace Cliptok.Modules
             [Command("relative")]
             [Aliases("r")]
             [Description("Returns the amount of time between now and a given Discord ID/snowflake")]
-            public async Task TimestampRelativeCmd(CommandContext ctx, [Description("The ID/snowflake to fetch the Unix timestamp for")] ulong snowflake)
+            public async Task TimestampRelativeCmd(CommandContext ctx, [Description("The ID/snowflake to fetch the relative timestamp for")] ulong snowflake)
             {
                 var msSinceEpoch = snowflake >> 22;
                 var msUnix = msSinceEpoch + 1420070400000;
@@ -374,7 +374,7 @@ namespace Cliptok.Modules
             [Command("fulldate")]
             [Aliases("f", "datetime")]
             [Description("Returns the fully-formatted date and time of a given Discord ID/snowflake")]
-            public async Task TimestampFullCmd(CommandContext ctx, [Description("The ID/snowflake to fetch the Unix timestamp for")] ulong snowflake)
+            public async Task TimestampFullCmd(CommandContext ctx, [Description("The ID/snowflake to fetch the full timestamp for")] ulong snowflake)
             {
                 var msSinceEpoch = snowflake >> 22;
                 var msUnix = msSinceEpoch + 1420070400000;

--- a/Modules/ModCmds.cs
+++ b/Modules/ModCmds.cs
@@ -351,8 +351,8 @@ namespace Cliptok.Modules
         [HomeServer, RequireHomeserverPerm(ServerPermLevel.Mod)]
         class TimestampCmds : BaseCommandModule
         {
-            [Command("unix")]
-            [Aliases("u", "epoch")]
+            [GroupCommand]
+            [Aliases("u", "unix", "epoch")]
             [Description("Returns the Unix timestamp of a given Discord ID/snowflake")]
             public async Task TimestampUnixCmd(CommandContext ctx, [Description("The ID/snowflake to fetch the Unix timestamp for")] ulong snowflake)
             {

--- a/Modules/ModCmds.cs
+++ b/Modules/ModCmds.cs
@@ -360,7 +360,7 @@ namespace Cliptok.Modules
                 var msUnix = msSinceEpoch + 1420070400000;
                 await ctx.RespondAsync($"{(msUnix / 1000).ToString()}");
             }
-            
+
             [Command("relative")]
             [Aliases("r")]
             [Description("Returns the amount of time between now and a given Discord ID/snowflake")]
@@ -370,7 +370,7 @@ namespace Cliptok.Modules
                 var msUnix = msSinceEpoch + 1420070400000;
                 await ctx.RespondAsync($"{Program.cfgjson.Emoji.ClockTime} <t:{(msUnix / 1000).ToString()}:R>");
             }
-            
+
             [Command("fulldate")]
             [Aliases("f", "datetime")]
             [Description("Returns the fully-formatted date and time of a given Discord ID/snowflake")]
@@ -382,11 +382,6 @@ namespace Cliptok.Modules
             }
 
         }
-            
-            
-            
-            
-        
 
         public static long ToUnixTimestamp(DateTime dateTime)
         {

--- a/Modules/ModCmds.cs
+++ b/Modules/ModCmds.cs
@@ -344,16 +344,49 @@ namespace Cliptok.Modules
             await Program.db.ListRightPushAsync("reminders", JsonConvert.SerializeObject(reminderObject));
             await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} I'll try my best to remind you about that on <t:{ToUnixTimestamp(t)}:f> (<t:{ToUnixTimestamp(t)}:R>)"); // (In roughly **{Warnings.TimeToPrettyFormat(t.Subtract(ctx.Message.Timestamp.DateTime), false)}**)");
         }
-
-        [Command("timestamp")]
+        
+        [Group("timestamp")]
         [Aliases("ts", "time")]
-        [Description("Returns the Unix timestamp of a given Discord ID/snowflake")]
-        public async Task TimestampCmd(CommandContext ctx, [Description("The ID/snowflake to fetch the Unix timestamp for")] ulong snowflake)
+        [Description("Returns various timestamps for a given Discord ID/snowflake")]
+        [HomeServer, RequireHomeserverPerm(ServerPermLevel.Mod)]
+        class DebugCmds : BaseCommandModule
         {
-            var msSinceEpoch = snowflake >> 22;
-            var msUnix = msSinceEpoch + 1420070400000;
-            await ctx.RespondAsync((msUnix / 1000).ToString());
+            [Command("unix")]
+            [Aliases("u", "epoch")]
+            [Description("Returns the Unix timestamp of a given Discord ID/snowflake")]
+            public async Task TimestampCmd(CommandContext ctx, [Description("The ID/snowflake to fetch the Unix timestamp for")] ulong snowflake)
+            {
+                var msSinceEpoch = snowflake >> 22;
+                var msUnix = msSinceEpoch + 1420070400000;
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.ClockTime} {(msUnix / 1000).ToString()}");
+            }
+            
+            [Command("relative")]
+            [Aliases("r")]
+            [Description("Returns the amount of time between now and a given Discord ID/snowflake")]
+            public async Task TimestampCmd(CommandContext ctx, [Description("The ID/snowflake to fetch the Unix timestamp for")] ulong snowflake)
+            {
+                var msSinceEpoch = snowflake >> 22;
+                var msUnix = msSinceEpoch + 1420070400000;
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.ClockTime} <t:{(msUnix / 1000).ToString()}:R>");
+            }
+            
+            [Command("fulldate")]
+            [Aliases("f", "datetime")]
+            [Description("Returns the fully-formatted date and time of a given Discord ID/snowflake")]
+            public async Task TimestampCmd(CommandContext ctx, [Description("The ID/snowflake to fetch the Unix timestamp for")] ulong snowflake)
+            {
+                var msSinceEpoch = snowflake >> 22;
+                var msUnix = msSinceEpoch + 1420070400000;
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.ClockTime} <t:{(msUnix / 1000).ToString()}:F>");
+            }
+
         }
+            
+            
+            
+            
+        
 
         public static long ToUnixTimestamp(DateTime dateTime)
         {

--- a/Modules/ModCmds.cs
+++ b/Modules/ModCmds.cs
@@ -358,7 +358,7 @@ namespace Cliptok.Modules
             {
                 var msSinceEpoch = snowflake >> 22;
                 var msUnix = msSinceEpoch + 1420070400000;
-                await ctx.RespondAsync($"{Program.cfgjson.Emoji.ClockTime} {(msUnix / 1000).ToString()}");
+                await ctx.RespondAsync($"{(msUnix / 1000).ToString()}");
             }
             
             [Command("relative")]


### PR DESCRIPTION
Extends !timestamp to allow the ability to specify the return format of the timestamp as either a full date/time instead of having to check it on other websites, or copy the returned timestamp and then format it yourself as a Discord timestamp, then send that back to the chat again.

I have done this all on my phone whilst i make a sandwich so no idea if it works plz check n test in devtok first thx