### PR TITLE
Remove moderator requirement for !timestamp

### DIFF
--- a/Modules/ModCmds.cs
+++ b/Modules/ModCmds.cs
@@ -348,7 +348,7 @@ namespace Cliptok.Modules
         [Group("timestamp")]
         [Aliases("ts", "time")]
         [Description("Returns various timestamps for a given Discord ID/snowflake")]
-        [HomeServer, RequireHomeserverPerm(ServerPermLevel.TrialMod)]
+        [HomeServer]
         class TimestampCmds : BaseCommandModule
         {
             [GroupCommand]


### PR DESCRIPTION
As discussed in #65, remove requirements for !timestamp