### PR TITLE
Change huggles/snuggles/etc in /Hug to lowercase

### DIFF
--- a/Modules/SlashCommands.cs
+++ b/Modules/SlashCommands.cs
@@ -275,19 +275,19 @@ namespace Cliptok.Modules
                 switch (new Random().Next(4))
                 {
                     case 0:
-                        await ctx.RespondAsync($"*{ctx.User.Mention} Snuggles {user.Mention}*");
+                        await ctx.RespondAsync($"*{ctx.User.Mention} snuggles {user.Mention}*");
                         break;
 
                     case 1:
-                        await ctx.RespondAsync($"*{ctx.User.Mention} Huggles {user.Mention}*");
+                        await ctx.RespondAsync($"*{ctx.User.Mention} huggles {user.Mention}*");
                         break;
 
                     case 2:
-                        await ctx.RespondAsync($"*{ctx.User.Mention} Cuddles {user.Mention}*");
+                        await ctx.RespondAsync($"*{ctx.User.Mention} cuddles {user.Mention}*");
                         break;
 
                     case 3:
-                        await ctx.RespondAsync($"*{ctx.User.Mention} Hugs {user.Mention}*");
+                        await ctx.RespondAsync($"*{ctx.User.Mention} hugs {user.Mention}*");
                         break;
                 }
             }


### PR DESCRIPTION
Having "huggles"/"snuggles"/etc be capitalized when they're not at the start of the message bothers me

Also - GitHub mentioned something about changing line endings when I committed the changes, so perhaps it's worth taking a look at...I don't want to have broken something.