### PR TITLE
Add !deletewarn as alias of !delwarn, update desc

### DIFF
--- a/Modules/Warnings.cs
+++ b/Modules/Warnings.cs
@@ -523,9 +523,8 @@ namespace Cliptok.Modules
 
         [
             Command("delwarn"),
-            Description("Delete a warning that was issued by mistake or later became invalid.\n" +
-            "You can only delete warnings issued by you, unless you are an Admin/Lead Moderator."),
-            Aliases("delwarm", "delwam"),
+            Description("Delete a warning that was issued by mistake or later became invalid."),
+            Aliases("delwarm", "delwam", "deletewarn"),
             HomeServer, RequireHomeserverPerm(ServerPermLevel.TrialMod)
         ]
         public async Task DelwarnCmd(


### PR DESCRIPTION
!delwarn is a shortened version of !deletewarn, so it makes sense to have the latter as an option. And the command description stated that only admins/lead moderators could delete other mods' warnings - this was changed a while ago, and now all moderators can delete any other moderators' warnings.