### PR TITLE
Improvements to appeal-bans

### DIFF
--- a/Modules/Bans.cs
+++ b/Modules/Bans.cs
@@ -66,7 +66,14 @@ namespace Cliptok.Modules
                 await guild.BanMemberAsync(targetUserId, deleteDays, reason);
                 if (permaBan)
                 {
-                    logOut = $"{Program.cfgjson.Emoji.Banned} <@{targetUserId}> was permanently banned by `{moderator.Username}#{moderator.Discriminator}` (`{moderatorId}`).\nReason: **{reason}**";
+                    if (appealable)
+                    {
+                        logOut = $"{Program.cfgjson.Emoji.Banned} <@{targetUserId}> was permanently banned (with appeal) by `{moderator.Username}#{moderator.Discriminator}` (`{moderatorId}`).\nReason: **{reason}**";
+                    }
+                    else
+                    {
+                        logOut = $"{Program.cfgjson.Emoji.Banned} <@{targetUserId}> was permanently banned by `{moderator.Username}#{moderator.Discriminator}` (`{moderatorId}`).\nReason: **{reason}**";
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Two improvements were made:

1. Make the `appeal` argument for `!ban` case-insensitive so that it is not included as part of the ban reason (and so the bot sends an appeal link) even if not typed in all-lowercase
2. When a user is banned and the `appeal` argument is included, log that an appeal link was included with the ban message in the configured `logChannel`