### PR TITLE
Contain the wild if/else beast that is CommandChecks/HomeServerPerms.cs

### DIFF
--- a/ .env-example
+++ b/ .env-example
@@ -1,0 +1,5 @@
+CLIPTOK_TOKEN=yourtokenhere
+CLIPTOK_GITHUB_TOKEN=githubtokenhere
+CLIPTOK_ANTIPHISHING_ENDPOINT=useyourimagination
+RAVY_API_TOKEN=goodluckfindingone
+CLOUDFLARED_TOKEN=ignoreifnotrelevant

--- a/CommandChecks/HomeServerPerms.cs
+++ b/CommandChecks/HomeServerPerms.cs
@@ -53,6 +53,14 @@
             else if (target.Roles.Contains(target.Guild.GetRole(Program.cfgjson.TrialModRole)))
                 return ServerPermLevel.TrialModerator;
             else if (tierRolesSize > 0) {
+                if (tierRolesSize > TierPerms.Count) {
+                    // If the size of their roles is over then the size of tier perms then just use the length
+                    // of the tier perms. It will exist as the tier role's list is bigger than the tier perms 
+                    // list.
+                    if (target.Roles.Contains(target.Guild.GetRole(Program.cfgjson.TierRoles[TierPerms.Count])))
+                        return TierPerms[TierPerms.Count];                 
+                }
+
                 foreach (int idx in Enumerable.Range(0, Program.cfgjson.TierRoles.Count).Reverse())
                 {
                     if (target.Roles.Contains(target.Guild.GetRole(Program.cfgjson.TierRoles[idx])))

--- a/CommandChecks/HomeServerPerms.cs
+++ b/CommandChecks/HomeServerPerms.cs
@@ -22,8 +22,22 @@
             Owner = int.MaxValue
         }
 
+        public static List<ServerPermLevel> TierPerms = new List<ServerPermLevel>() { 
+            ServerPermLevel.Tier1,
+            ServerPermLevel.Tier2,
+            ServerPermLevel.Tier3,
+            ServerPermLevel.Tier4,
+            ServerPermLevel.Tier5,
+            ServerPermLevel.Tier6,
+            ServerPermLevel.Tier7,
+            ServerPermLevel.Tier8,
+            ServerPermLevel.TierS,
+            ServerPermLevel.TierX,            
+        };
+        
         public static ServerPermLevel GetPermLevel(DiscordMember target)
         {
+            var tierRolesSize = Program.cfgjson.TierRoles.Count;
             if (target.Guild.Id != Program.cfgjson.ServerID)
                 return ServerPermLevel.Nothing;
 
@@ -38,26 +52,34 @@
                 return ServerPermLevel.Muted;
             else if (target.Roles.Contains(target.Guild.GetRole(Program.cfgjson.TrialModRole)))
                 return ServerPermLevel.TrialModerator;
-            else if (target.Roles.Contains(target.Guild.GetRole(Program.cfgjson.TierRoles[9])))
-                return ServerPermLevel.TierX;
-            else if (target.Roles.Contains(target.Guild.GetRole(Program.cfgjson.TierRoles[8])))
-                return ServerPermLevel.TierS;
-            else if (target.Roles.Contains(target.Guild.GetRole(Program.cfgjson.TierRoles[7])))
-                return ServerPermLevel.Tier8;
-            else if (target.Roles.Contains(target.Guild.GetRole(Program.cfgjson.TierRoles[6])))
-                return ServerPermLevel.Tier7;
-            else if (target.Roles.Contains(target.Guild.GetRole(Program.cfgjson.TierRoles[5])))
-                return ServerPermLevel.Tier6;
-            else if (target.Roles.Contains(target.Guild.GetRole(Program.cfgjson.TierRoles[4])))
-                return ServerPermLevel.Tier5;
-            else if (target.Roles.Contains(target.Guild.GetRole(Program.cfgjson.TierRoles[3])))
-                return ServerPermLevel.Tier4;
-            else if (target.Roles.Contains(target.Guild.GetRole(Program.cfgjson.TierRoles[2])))
-                return ServerPermLevel.Tier3;
-            else if (target.Roles.Contains(target.Guild.GetRole(Program.cfgjson.TierRoles[1])))
-                return ServerPermLevel.Tier2;
-            else if (target.Roles.Contains(target.Guild.GetRole(Program.cfgjson.TierRoles[0])))
-                return ServerPermLevel.Tier1;
+            else if (tierRolesSize > 0) {
+                foreach (int idx in Enumerable.Range(0, Program.cfgjson.TierRoles.Count).Reverse())
+                {
+                    if (target.Roles.Contains(target.Guild.GetRole(Program.cfgjson.TierRoles[idx])))
+                        return TierPerms[idx];
+                }
+                return ServerPermLevel.Nothing;
+            }
+            // else if (target.Roles.Contains(target.Guild.GetRole(Program.cfgjson.TierRoles[9])))
+            //     return ServerPermLevel.TierX;
+            // else if (target.Roles.Contains(target.Guild.GetRole(Program.cfgjson.TierRoles[8])))
+            //     return ServerPermLevel.TierS;
+            // else if (target.Roles.Contains(target.Guild.GetRole(Program.cfgjson.TierRoles[7])))
+            //     return ServerPermLevel.Tier8;
+            // else if (target.Roles.Contains(target.Guild.GetRole(Program.cfgjson.TierRoles[6])))
+            //     return ServerPermLevel.Tier7;
+            // else if (target.Roles.Contains(target.Guild.GetRole(Program.cfgjson.TierRoles[5])))
+            //     return ServerPermLevel.Tier6;
+            // else if (target.Roles.Contains(target.Guild.GetRole(Program.cfgjson.TierRoles[4])))
+            //     return ServerPermLevel.Tier5;
+            // else if (target.Roles.Contains(target.Guild.GetRole(Program.cfgjson.TierRoles[3])))
+            //     return ServerPermLevel.Tier4;
+            // else if (target.Roles.Contains(target.Guild.GetRole(Program.cfgjson.TierRoles[2])))
+            //     return ServerPermLevel.Tier3;
+            // else if (target.Roles.Contains(target.Guild.GetRole(Program.cfgjson.TierRoles[1])))
+            //     return ServerPermLevel.Tier2;
+            // else if (target.Roles.Contains(target.Guild.GetRole(Program.cfgjson.TierRoles[0])))
+            //     return ServerPermLevel.Tier1;
             else
                 return ServerPermLevel.Nothing;
         }

--- a/CommandChecks/HomeServerPerms.cs
+++ b/CommandChecks/HomeServerPerms.cs
@@ -54,7 +54,7 @@
                 return ServerPermLevel.TrialModerator;
             else if (tierRolesSize > 0) {
                 if (tierRolesSize > TierPerms.Count) {
-                    // If the size of their roles is over then the size of tier perms then just use the length
+                    // If the size of the tier roles is over then the size of tier perms then just use the length
                     // of the tier perms. It will exist as the tier role's list is bigger than the tier perms 
                     // list.
                     if (target.Roles.Contains(target.Guild.GetRole(Program.cfgjson.TierRoles[TierPerms.Count])))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,9 @@ services:
         source: ./Lists/Private
         target: /app/Lists/Private
       # Uncomment the below lines to use your own config file.
-      - type: bind
-        source: ./config.dev.json
-        target: /app/config.json
+      # - type: bind
+      #   source: ./config.dev.json
+      #   target: /app/config.json
     environment:
       # Overrides your configs Redis options for use with Docker Compose
       #  I don't advise changing this unless you have a strange setup
@@ -28,19 +28,19 @@ services:
         target: /data
     command: --appendonly yes
 
-# # You may want to comment out everything below if you're not Erisa.
-#   redis-exposer:
-#     image: ghcr.io/erisa/redis-exposer
-#     restart: always
-#     env_file:
-#      - .exposer.env
-#   cloudflared:
-#     image: erisamoe/cloudflared
-#     restart: always
-#     command: tunnel --no-autoupdate run --token ${CLOUDFLARED_TOKEN}
-#   watchtower:
-#     image: containrrr/watchtower
-#     volumes:
-#       - /var/run/docker.sock:/var/run/docker.sock
-#     command: --interval 30 --label-enable
-#     restart: always
+# You may want to comment out everything below if you're not Erisa.
+  redis-exposer:
+    image: ghcr.io/erisa/redis-exposer
+    restart: always
+    env_file:
+     - .exposer.env
+  cloudflared:
+    image: erisamoe/cloudflared
+    restart: always
+    command: tunnel --no-autoupdate run --token ${CLOUDFLARED_TOKEN}
+  watchtower:
+    image: containrrr/watchtower
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: --interval 30 --label-enable
+    restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,9 @@ services:
         source: ./Lists/Private
         target: /app/Lists/Private
       # Uncomment the below lines to use your own config file.
-      #- type: bind
-      #  source: ./config.dev.json
-      # target: /app/config.json
+      - type: bind
+        source: ./config.dev.json
+        target: /app/config.json
     environment:
       # Overrides your configs Redis options for use with Docker Compose
       #  I don't advise changing this unless you have a strange setup
@@ -28,19 +28,19 @@ services:
         target: /data
     command: --appendonly yes
 
-# You may want to comment out everything below if you're not Erisa.
-  redis-exposer:
-    image: ghcr.io/erisa/redis-exposer
-    restart: always
-    env_file:
-     - .exposer.env
-  cloudflared:
-    image: erisamoe/cloudflared
-    restart: always
-    command: tunnel --no-autoupdate run --token ${CLOUDFLARED_TOKEN}
-  watchtower:
-    image: containrrr/watchtower
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    command: --interval 30 --label-enable
-    restart: always
+# # You may want to comment out everything below if you're not Erisa.
+#   redis-exposer:
+#     image: ghcr.io/erisa/redis-exposer
+#     restart: always
+#     env_file:
+#      - .exposer.env
+#   cloudflared:
+#     image: erisamoe/cloudflared
+#     restart: always
+#     command: tunnel --no-autoupdate run --token ${CLOUDFLARED_TOKEN}
+#   watchtower:
+#     image: containrrr/watchtower
+#     volumes:
+#       - /var/run/docker.sock:/var/run/docker.sock
+#     command: --interval 30 --label-enable
+#     restart: always


### PR DESCRIPTION
This PR "changes" how tier role checks are handled in [`CommandChecks/HomeServerPerms.cs`](CommandChecks/HomeServerPerms.cs) by changing it from a long list of if/else's to a for-loop. I'm not a c# dev so I'm not sure if this is the best way, but it looks nicer. 

I have only tested the anti-invite with this change. I'd be interested to see if other things that rely on this still work. Please let me know of anything else that should be tested as a result of this change.