### PR TITLE
Add /lockdown & /unlock and the ability to disable sending messages in threads without archiving them

### DIFF
--- a/Commands/InteractionCommands/AnnouncementInteractions.cs
+++ b/Commands/InteractionCommands/AnnouncementInteractions.cs
@@ -136,7 +136,7 @@
                     lockDuration = TimeSpan.FromHours(2);
                 }
 
-                await LockdownHelpers.LockChannelAsync(channel: ctx.Channel, duration: lockDuration);
+                await LockdownHelpers.LockChannelAsync(user: ctx.User, channel: ctx.Channel, duration: lockDuration);
             }
         }
 

--- a/Commands/InteractionCommands/LockdownInteractions.cs
+++ b/Commands/InteractionCommands/LockdownInteractions.cs
@@ -1,0 +1,159 @@
+namespace Cliptok.Commands.InteractionCommands
+{
+    class LockdownInteractions : ApplicationCommandModule
+    {
+        public static bool ongoingLockdown = false;
+
+        [SlashCommandGroup("lockdown", "Lock the current channel or all channels in the server, preventing new messages. See also: unlock")]
+        [HomeServer, SlashRequireHomeserverPerm(ServerPermLevel.Moderator), RequireBotPermissions(Permissions.ManageChannels)]
+        public class LockdownCmds
+        {
+            [SlashCommand("channel", "Lock the current channel. See also: unlock channel")]
+            public async Task LockdownChannelCommand(
+                InteractionContext ctx,
+                [Option("reason", "The reason for the lockdown.")] string reason = "",
+                [Option("time", "The length of time to lock the channel for.")] string time = null,
+                [Option("lockthreads", "Whether to lock this channel's threads. Disables sending messages, but does not archive them.")] bool lockThreads = false)
+            {
+                await ctx.CreateResponseAsync(InteractionResponseType.DeferredChannelMessageWithSource, new DiscordInteractionResponseBuilder().AsEphemeral(true));
+
+                if (ctx.Channel.Type is ChannelType.PublicThread or ChannelType.PrivateThread or ChannelType.NewsThread)
+                {
+                    if (lockThreads)
+                    {
+                        await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent($"{Program.cfgjson.Emoji.Denied} You can't lock this channel!\n`/lockdown` with `lockthreads` cannot be used inside of a thread. If you meant to lock {ctx.Channel.Parent.Mention} and all of its threads, use the command there.\n\nIf you meant to only lock this thread, use `!lock` instead, or use `/lockdown` with `lockthreads` set to False.").AsEphemeral(true));
+                        return;
+                    }
+
+                    var thread = (DiscordThreadChannel)ctx.Channel;
+                    await Program.db.SetRemoveAsync("openthreads", thread.Id);
+
+                    await thread.ModifyAsync(a =>
+                    {
+                        a.IsArchived = true;
+                        a.Locked = true;
+                    });
+
+                    await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent("Thread locked successfully!").AsEphemeral(true));
+                    return;
+                }
+
+                TimeSpan? lockDuration = null;
+
+                if (!string.IsNullOrWhiteSpace(time))
+                {
+                    lockDuration = HumanDateParser.HumanDateParser.Parse(time).Subtract(ctx.Interaction.CreationTimestamp.LocalDateTime);
+                }
+
+                var currentChannel = ctx.Channel;
+                if (!Program.cfgjson.LockdownEnabledChannels.Contains(currentChannel.Id))
+                {
+                    await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent($"{Program.cfgjson.Emoji.Denied} You can't lock or unlock this channel!\nIf this is in error, add its ID (`{currentChannel.Id}`) to the lockdown whitelist."));
+                    return;
+                }
+
+                if (ongoingLockdown)
+                {
+                    await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent($"{Program.cfgjson.Emoji.Error} A mass lockdown or unlock is already ongoing. Refusing your request to avoid conflicts, sorry."));
+                    return;
+                }
+
+                bool success = await LockdownHelpers.LockChannelAsync(channel: currentChannel, duration: lockDuration, reason: reason, lockThreads: lockThreads);
+                if (success)
+                    await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent("Channel locked successfully.").AsEphemeral(true));
+                else
+                    await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent("Failed to lock this channel!").AsEphemeral(true));
+            }
+
+            [SlashCommand("all", "Lock all lockable channels in the server. See also: unlock all")]
+            public async Task LockdownAllCommand(
+                InteractionContext ctx,
+                [Option("reason", "The reason for the lockdown.")] string reason = "",
+                [Option("time", "The length of time to lock the channels for.")] string time = null,
+                [Option("lockthreads", "Whether to lock threads. Disables sending messages, but does not archive them.")] bool lockThreads = false)
+            {
+                await ctx.CreateResponseAsync(InteractionResponseType.DeferredChannelMessageWithSource, new DiscordInteractionResponseBuilder().WithContent("test deferred response"));
+
+                ongoingLockdown = true;
+                await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent($"{Program.cfgjson.Emoji.Loading} Working on it, please hold..."));
+
+                TimeSpan? lockDuration = null;
+
+                if (!string.IsNullOrWhiteSpace(time))
+                {
+                    lockDuration = HumanDateParser.HumanDateParser.Parse(time).Subtract(ctx.Interaction.CreationTimestamp.LocalDateTime);
+                }
+
+                foreach (var chanID in Program.cfgjson.LockdownEnabledChannels)
+                {
+                    try
+                    {
+                        var channel = await ctx.Client.GetChannelAsync(chanID);
+                        await LockdownHelpers.LockChannelAsync(channel: channel, duration: lockDuration, reason: reason, lockThreads: lockThreads);
+                    }
+                    catch
+                    {
+
+                    }
+
+                }
+                await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent($"{Program.cfgjson.Emoji.Success} Done!"));
+                ongoingLockdown = false;
+                return;
+            }
+        }
+
+        [SlashCommandGroup("unlock", "Unlock the current channel or all channels in the server, allowing new messages. See also: lockdown")]
+        [HomeServer, SlashRequireHomeserverPerm(ServerPermLevel.Moderator), RequireBotPermissions(Permissions.ManageChannels)]
+        public class UnlockCmds
+        {
+            [SlashCommand("channel", "Unlock the current channel. See also: lockdown")]
+            public async Task UnlockChannelCommand(InteractionContext ctx, [Option("reason", "The reason for the unlock.")] string reason = "")
+            {
+                await ctx.CreateResponseAsync(InteractionResponseType.DeferredChannelMessageWithSource, new DiscordInteractionResponseBuilder().AsEphemeral(true));
+
+                var currentChannel = ctx.Channel;
+                if (!Program.cfgjson.LockdownEnabledChannels.Contains(currentChannel.Id))
+                {
+                    await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent($"{Program.cfgjson.Emoji.Denied} You can't lock or unlock this channel!\nIf this is in error, add its ID (`{currentChannel.Id}`) to the lockdown whitelist.").AsEphemeral(true));
+                    return;
+                }
+
+                if (ongoingLockdown)
+                {
+                    await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent($"{Program.cfgjson.Emoji.Error} A mass lockdown or unlock is already ongoing. Refusing your request. sorry.").AsEphemeral(true));
+                    return;
+                }
+                bool success = await LockdownHelpers.UnlockChannel(currentChannel, ctx.Member);
+                if (success)
+                    await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent("Channel unlocked successfully.").AsEphemeral(true));
+                else
+                    await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent("Failed to unlock this channel!").AsEphemeral(true));
+            }
+
+            [SlashCommand("all", "Unlock all lockable channels in the server. See also: lockdown all")]
+            public async Task UnlockAllCommand(InteractionContext ctx, [Option("reason", "The reason for the unlock.")] string reason = "")
+            {
+                await ctx.CreateResponseAsync(InteractionResponseType.DeferredChannelMessageWithSource);
+
+                ongoingLockdown = true;
+                await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent($"{Program.cfgjson.Emoji.Loading} Working on it, please hold..."));
+                foreach (var chanID in Program.cfgjson.LockdownEnabledChannels)
+                {
+                    try
+                    {
+                        var currentChannel = await ctx.Client.GetChannelAsync(chanID);
+                        await LockdownHelpers.UnlockChannel(currentChannel, ctx.Member, true);
+                    }
+                    catch
+                    {
+
+                    }
+                }
+                await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent($"{Program.cfgjson.Emoji.Success} Done!"));
+                ongoingLockdown = false;
+                return;
+            }
+        }
+    }
+}

--- a/Commands/InteractionCommands/LockdownInteractions.cs
+++ b/Commands/InteractionCommands/LockdownInteractions.cs
@@ -11,7 +11,7 @@ namespace Cliptok.Commands.InteractionCommands
             [SlashCommand("channel", "Lock the current channel. See also: unlock channel")]
             public async Task LockdownChannelCommand(
                 InteractionContext ctx,
-                [Option("reason", "The reason for the lockdown.")] string reason = "",
+                [Option("reason", "The reason for the lockdown.")] string reason = "No reason specified.",
                 [Option("time", "The length of time to lock the channel for.")] string time = null,
                 [Option("lockthreads", "Whether to lock this channel's threads. Disables sending messages, but does not archive them.")] bool lockThreads = false)
             {
@@ -58,7 +58,7 @@ namespace Cliptok.Commands.InteractionCommands
                     return;
                 }
 
-                bool success = await LockdownHelpers.LockChannelAsync(channel: currentChannel, duration: lockDuration, reason: reason, lockThreads: lockThreads);
+                bool success = await LockdownHelpers.LockChannelAsync(user: ctx.User, channel: currentChannel, duration: lockDuration, reason: reason, lockThreads: lockThreads);
                 if (success)
                     await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent("Channel locked successfully.").AsEphemeral(true));
                 else
@@ -89,7 +89,7 @@ namespace Cliptok.Commands.InteractionCommands
                     try
                     {
                         var channel = await ctx.Client.GetChannelAsync(chanID);
-                        await LockdownHelpers.LockChannelAsync(channel: channel, duration: lockDuration, reason: reason, lockThreads: lockThreads);
+                        await LockdownHelpers.LockChannelAsync(user: ctx.User, channel: channel, duration: lockDuration, reason: reason, lockThreads: lockThreads);
                     }
                     catch
                     {
@@ -143,7 +143,7 @@ namespace Cliptok.Commands.InteractionCommands
                     try
                     {
                         var currentChannel = await ctx.Client.GetChannelAsync(chanID);
-                        await LockdownHelpers.UnlockChannel(currentChannel, ctx.Member, true);
+                        await LockdownHelpers.UnlockChannel(currentChannel, ctx.Member, reason, true);
                     }
                     catch
                     {

--- a/Commands/Lockdown.cs
+++ b/Commands/Lockdown.cs
@@ -78,7 +78,7 @@ namespace Cliptok.Commands
                     try
                     {
                         var channel = await ctx.Client.GetChannelAsync(chanID);
-                        await LockdownHelpers.LockChannelAsync(channel: channel);
+                        await LockdownHelpers.LockChannelAsync(user: ctx.User, channel: channel);
                     }
                     catch
                     {
@@ -94,7 +94,7 @@ namespace Cliptok.Commands
 
             await ctx.Message.DeleteAsync();
 
-            await LockdownHelpers.LockChannelAsync(channel: currentChannel, duration: lockDuration, reason: reason);
+            await LockdownHelpers.LockChannelAsync(user: ctx.User, channel: currentChannel, duration: lockDuration, reason: reason);
         }
 
         [Command("unlock")]
@@ -135,7 +135,7 @@ namespace Cliptok.Commands
                 ongoingLockdown = false;
                 return;
             }
-            await LockdownHelpers.UnlockChannel(currentChannel, ctx.Member);
+            await LockdownHelpers.UnlockChannel(currentChannel, ctx.Member, reason);
         }
 
     }

--- a/Commands/Lockdown.cs
+++ b/Commands/Lockdown.cs
@@ -78,7 +78,7 @@ namespace Cliptok.Commands
                     try
                     {
                         var channel = await ctx.Client.GetChannelAsync(chanID);
-                        await LockdownHelpers.LockChannelAsync(channel: channel, reason: reason);
+                        await LockdownHelpers.LockChannelAsync(channel: channel);
                     }
                     catch
                     {

--- a/Helpers/LockdownHelpers.cs
+++ b/Helpers/LockdownHelpers.cs
@@ -2,7 +2,7 @@
 {
     public class LockdownHelpers
     {
-        public static async Task<bool> LockChannelAsync(DiscordChannel channel, TimeSpan? duration = null, string reason = "", bool lockThreads = false)
+        public static async Task<bool> LockChannelAsync(DiscordUser user, DiscordChannel channel, TimeSpan? duration = null, string reason = "No reason specified.", bool lockThreads = false)
         {
             if (!Program.cfgjson.LockdownEnabledChannels.Contains(channel.Id))
             {
@@ -24,22 +24,22 @@
                         {
                             if (overwrite.Denied.HasPermission(Permissions.AccessChannels))
                             {
-                                await channel.AddOverwriteAsync(channel.Guild.EveryoneRole, Permissions.None, Permissions.SendMessages | Permissions.AccessChannels | Permissions.SendMessagesInThreads, "Lockdown command");
+                                await channel.AddOverwriteAsync(channel.Guild.EveryoneRole, Permissions.None, Permissions.SendMessages | Permissions.AccessChannels | Permissions.SendMessagesInThreads, $"[Lockdown by {user.Username}#{user.Discriminator}]: {reason}");
                             }
                             else
                             {
-                                await channel.AddOverwriteAsync(channel.Guild.EveryoneRole, Permissions.None, Permissions.SendMessages | Permissions.SendMessagesInThreads, "Lockdown command");
+                                await channel.AddOverwriteAsync(channel.Guild.EveryoneRole, Permissions.None, Permissions.SendMessages | Permissions.SendMessagesInThreads, $"[Lockdown by {user.Username}#{user.Discriminator}]: {reason}");
                             }
                         }
                         else
                         {
                             if (overwrite.Denied.HasPermission(Permissions.AccessChannels))
                             {
-                                await channel.AddOverwriteAsync(channel.Guild.EveryoneRole, Permissions.None, Permissions.SendMessages | Permissions.AccessChannels, "Lockdown command");
+                                await channel.AddOverwriteAsync(channel.Guild.EveryoneRole, Permissions.None, Permissions.SendMessages | Permissions.AccessChannels, $"[Lockdown by {user.Username}#{user.Discriminator}]: {reason}");
                             }
                             else
                             {
-                                await channel.AddOverwriteAsync(channel.Guild.EveryoneRole, Permissions.None, Permissions.SendMessages, "Lockdown command");
+                                await channel.AddOverwriteAsync(channel.Guild.EveryoneRole, Permissions.None, Permissions.SendMessages, $"[Lockdown by {user.Username}#{user.Discriminator}]: {reason}");
                             }
                         }
                     }
@@ -56,7 +56,7 @@
             }
 
             string msg;
-            if (reason == "")
+            if (reason == "" || reason == "No reason specified.")
                 msg = $"{Program.cfgjson.Emoji.Locked} This channel has been locked by a Moderator.";
             else
                 msg = $"{Program.cfgjson.Emoji.Locked} This channel has been locked: **{reason}**";
@@ -71,7 +71,7 @@
             return true;
         }
 
-        public static async Task<bool> UnlockChannel(DiscordChannel discordChannel, DiscordMember discordMember, bool isMassUnlock = false)
+        public static async Task<bool> UnlockChannel(DiscordChannel discordChannel, DiscordMember discordMember, string reason = "No reason specified.", bool isMassUnlock = false)
         {
             bool success = false;
             var permissions = discordChannel.PermissionOverwrites.ToArray();
@@ -103,7 +103,7 @@
                         }
 
                         success = true;
-                        await discordChannel.AddOverwriteAsync(discordChannel.Guild.EveryoneRole, newOverwrite.Allowed, newOverwrite.Denied);
+                        await discordChannel.AddOverwriteAsync(discordChannel.Guild.EveryoneRole, newOverwrite.Allowed, newOverwrite.Denied, $"[Unlock by {discordMember.Username}#{discordMember.Discriminator}]: {reason}");
                     }
 
                     if (await permission.GetRoleAsync() == discordChannel.Guild.GetRole(Program.cfgjson.ModRole)

--- a/Helpers/LockdownHelpers.cs
+++ b/Helpers/LockdownHelpers.cs
@@ -14,6 +14,7 @@
             await channel.AddOverwriteAsync(channel.Guild.CurrentMember, Permissions.SendMessages, Permissions.None, "Failsafe 1 for Lockdown");
             await channel.AddOverwriteAsync(channel.Guild.GetRole(Program.cfgjson.ModRole), Permissions.SendMessages, Permissions.None, "Failsafe 2 for Lockdown");
 
+            bool everyoneRoleChanged = false;
             foreach (DiscordOverwrite overwrite in existingOverwrites)
             {
                 if (overwrite.Type == OverwriteType.Role)
@@ -42,16 +43,29 @@
                                 await channel.AddOverwriteAsync(channel.Guild.EveryoneRole, Permissions.None, Permissions.SendMessages, $"[Lockdown by {user.Username}#{user.Discriminator}]: {reason}");
                             }
                         }
+
+                        everyoneRoleChanged = true;
                     }
                     else
                     {
                         await channel.AddOverwriteAsync(await overwrite.GetRoleAsync(), overwrite.Allowed, overwrite.Denied);
-
                     }
                 }
                 else
                 {
                     await channel.AddOverwriteAsync(await overwrite.GetMemberAsync(), overwrite.Allowed, overwrite.Denied);
+                }
+            }
+
+            if (!everyoneRoleChanged)
+            {
+                if (lockThreads)
+                {
+                    await channel.AddOverwriteAsync(channel.Guild.EveryoneRole, Permissions.None, Permissions.SendMessages | Permissions.SendMessagesInThreads, $"[Lockdown by {user.Username}#{user.Discriminator}]: {reason}");
+                }
+                else
+                {
+                    await channel.AddOverwriteAsync(channel.Guild.EveryoneRole, Permissions.None, Permissions.SendMessages, $"[Lockdown by {user.Username}#{user.Discriminator}]: {reason}");
                 }
             }
 


### PR DESCRIPTION
This PR closes #138.

These changes:
- Add slash commands for `/lockdown` and `/unlock`.
- Add support for a `lockthreads` argument that, when set to True, disables the "Send Messages in Threads" permission for the channel(s) being locked (this argument is currently only available for the slash command, not added to `!lockdown`).
- Modify the `LockChannelAsync` helper so that it returns success as a bool (previously `UnlockChannel` did but `LockChannelAsync` did not).
- Prevent the bot from sending a "This channel is not locked, or unlock failed" error message in channels that are already unlocked if the current operation is a mass-unlock (`!unlock all` or `/unlock all`). It will continue to send this error if it fails to unlock a single channel (`!unlock` or `/unlock channel`).

The slash commands added are:
- `/lockdown channel`, which will lock the current channel with an optional reason, unlock time, and whether to disable "Send Messages in Threads" (defaults to false).
- `/lockdown all`, with the same arguments, which will apply to all lockable channels in the server.
- `/unlock channel`, which will unlock the current channel with an optional reason.
- `/unlock all`, which will unlock all locked channels with an optional reason.

When used in a channel:
- `/lockdown` without `lockthreads` (or with it set to False) will lock the current channel. Does not modify threads at all (doesn't change permissions or archive them).
- `/lockdown` with `lockthreads` set to True locks the channel and disables the "Send Messages in Threads" permission. Threads are not archived.
- `!lockdown` locks the channel. This command does not modify threads at all (doesn't change permissions or archive them).

When used in a thread:
- `/lockdown` without `lockthreads` (or with it set to False) will archive and lock the thread, similar to `!lockdown`/`!lock`. Does not modify the parent channel.
- `/lockdown` with `lockthreads` set to True throws an error suggesting that you either use the command in the parent channel to lock it and its threads, or use `!lock` (`!lockdown` works too, `!lock` is just an alias) or `/lockdown` with `lockthreads` set to False to lock the current thread only (which will lock and archive the thread). [Screenshot](https://cdn.floatingmilkshake.com/kA4xgYMNBW.png)

Reasons for lockdowns and unlocks are now also logged to the Audit Log in this format: `[Lockdown by FloatingMilkshake#7777]: blah`, `[Unlock by FloatingMilkshake#7777]: blah`. If no reason is provided when the command is issued, the reason defaults to `No reason specified.`.