### PR TITLE
Update Audit Log reason for automatic unlocks

### DIFF
--- a/Helpers/LockdownHelpers.cs
+++ b/Helpers/LockdownHelpers.cs
@@ -117,7 +117,10 @@
                         }
 
                         success = true;
-                        await discordChannel.AddOverwriteAsync(discordChannel.Guild.EveryoneRole, newOverwrite.Allowed, newOverwrite.Denied, $"[Unlock by {discordMember.Username}#{discordMember.Discriminator}]: {reason}");
+                        if (discordMember.Id == Program.discord.CurrentUser.Id)
+                            await discordChannel.AddOverwriteAsync(discordChannel.Guild.EveryoneRole, newOverwrite.Allowed, newOverwrite.Denied, "Lockdown has naturally expired.");
+                        else
+                            await discordChannel.AddOverwriteAsync(discordChannel.Guild.EveryoneRole, newOverwrite.Allowed, newOverwrite.Denied, $"[Unlock by {discordMember.Username}#{discordMember.Discriminator}]: {reason}");
                     }
 
                     if (await permission.GetRoleAsync() == discordChannel.Guild.GetRole(Program.cfgjson.ModRole)


### PR DESCRIPTION
If a lockdown is set with a timer, Cliptok will now log the permission changes to the Audit Log with the reason `Lockdown has naturally expired.` (previously `[Unlock by Cliptok]: No reason specified.`).