### PR TITLE
Add /clear

### DIFF
--- a/Commands/InteractionCommands/ClearInteractions.cs
+++ b/Commands/InteractionCommands/ClearInteractions.cs
@@ -8,14 +8,14 @@
         [HomeServer, SlashRequireHomeserverPerm(ServerPermLevel.TrialModerator), RequireBotPermissions(Permissions.ManageMessages), SlashCommandPermissions(Permissions.ModerateMembers)]
         public async Task ClearSlashCommand(InteractionContext ctx,
             [Option("count", "The number of messages to delete. Required if you don't use the 'upto' argument.")] long count = 0,
-            [Option("upto", "Optionally delete messages up to (not including) this one. Accepts IDs and links.")] string upTo = "",
+            [Option("up_to", "Optionally delete messages up to (not including) this one. Accepts IDs and links.")] string upTo = "",
             [Option("user", "Optionally filter the deletion to a specific user.")] DiscordUser user = default,
-            [Option("ignoremods", "Optionally filter the deletion to only messages sent by users who are not Moderators.")] bool ignoreMods = false,
+            [Option("ignore_mods", "Optionally filter the deletion to only messages sent by users who are not Moderators.")] bool ignoreMods = false,
             [Option("match", "Optionally filter the deletion to only messages containing certain text.")] string match = "",
-            [Option("botsonly", "Optionally filter the deletion to only bots.")] bool botsOnly = false,
-            [Option("humansonly", "Optionally filter the deletion to only humans.")] bool humansOnly = false,
-            [Option("imagesonly", "Optionally filter the deletion to only messages containing images.")] bool imagesOnly = false,
-            [Option("linksonly", "Optionally filter the deletion to only messages containing links.")] bool linksOnly = false
+            [Option("bots_only", "Optionally filter the deletion to only bots.")] bool botsOnly = false,
+            [Option("humans_only", "Optionally filter the deletion to only humans.")] bool humansOnly = false,
+            [Option("images_only", "Optionally filter the deletion to only messages containing images.")] bool imagesOnly = false,
+            [Option("links_only", "Optionally filter the deletion to only messages containing links.")] bool linksOnly = false
         )
         {
             await ctx.CreateResponseAsync(InteractionResponseType.DeferredChannelMessageWithSource, new DiscordInteractionResponseBuilder().AsEphemeral(true));

--- a/Commands/InteractionCommands/ClearInteractions.cs
+++ b/Commands/InteractionCommands/ClearInteractions.cs
@@ -153,7 +153,7 @@
             {
                 if (humansOnly)
                 {
-                    await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent($"{Program.cfgjson.Emoji.Error} You can't use `botsonly` and `humansonly` together! Pick one or the other please.").AsEphemeral(true));
+                    await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent($"{Program.cfgjson.Emoji.Error} You can't use `bots_only` and `humans_only` together! Pick one or the other please.").AsEphemeral(true));
                     return;
                 }
 
@@ -183,7 +183,7 @@
             {
                 if (linksOnly)
                 {
-                    await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent($"{Program.cfgjson.Emoji.Error} You can't use `imagesonly` and `linksonly` together! Pick one or the other please.").AsEphemeral(true));
+                    await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent($"{Program.cfgjson.Emoji.Error} You can't use `images_only` and `links_only` together! Pick one or the other please.").AsEphemeral(true));
                     return;
                 }
 

--- a/Commands/InteractionCommands/ClearInteractions.cs
+++ b/Commands/InteractionCommands/ClearInteractions.cs
@@ -27,6 +27,12 @@
                 return;
             }
 
+            if (count == 0 && upTo == "")
+            {
+                await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent($"{Program.cfgjson.Emoji.Error} I need to know how many messages to delete! Please provide a value for `count` or `up_to`.").AsEphemeral(true));
+                return;
+            }
+
             // If count is too low or too high, refuse the request
 
             if (count < 0)

--- a/Commands/InteractionCommands/ClearInteractions.cs
+++ b/Commands/InteractionCommands/ClearInteractions.cs
@@ -7,21 +7,21 @@
         [SlashCommand("clear", "Delete many messages from the current channel.", defaultPermission: false)]
         [HomeServer, SlashRequireHomeserverPerm(ServerPermLevel.TrialModerator), RequireBotPermissions(Permissions.ManageMessages), SlashCommandPermissions(Permissions.ModerateMembers)]
         public async Task ClearSlashCommand(InteractionContext ctx,
-            [Option("count", "The number of messages to delete. Required if you don't use the 'upto' argument.")] long count = 0,
+            [Option("count", "The number of messages to consider for deletion. Required if you don't use the 'upto' argument.")] long count = 0,
             [Option("up_to", "Optionally delete messages up to (not including) this one. Accepts IDs and links.")] string upTo = "",
             [Option("user", "Optionally filter the deletion to a specific user.")] DiscordUser user = default,
             [Option("ignore_mods", "Optionally filter the deletion to only messages sent by users who are not Moderators.")] bool ignoreMods = false,
             [Option("match", "Optionally filter the deletion to only messages containing certain text.")] string match = "",
             [Option("bots_only", "Optionally filter the deletion to only bots.")] bool botsOnly = false,
             [Option("humans_only", "Optionally filter the deletion to only humans.")] bool humansOnly = false,
-            [Option("images_only", "Optionally filter the deletion to only messages containing images.")] bool imagesOnly = false,
+            [Option("attachments_only", "Optionally filter the deletion to only messages with attachments.")] bool attachmentsOnly = false,
             [Option("links_only", "Optionally filter the deletion to only messages containing links.")] bool linksOnly = false
         )
         {
             await ctx.CreateResponseAsync(InteractionResponseType.DeferredChannelMessageWithSource, new DiscordInteractionResponseBuilder().AsEphemeral(true));
 
             // If all args are unset
-            if (count == 0 && upTo == "" && user == default && ignoreMods == false && match == "" && botsOnly == false && humansOnly == false && imagesOnly == false && linksOnly == false)
+            if (count == 0 && upTo == "" && user == default && ignoreMods == false && match == "" && botsOnly == false && humansOnly == false && attachmentsOnly == false && linksOnly == false)
             {
                 await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent($"{Program.cfgjson.Emoji.Error} You must provide at least one argument! I need to know which messages to delete.").AsEphemeral(true));
                 return;
@@ -79,7 +79,6 @@
                         Constants.RegexConstants.discord_link_rx.Match(upTo).Groups[2].Value != ctx.Channel.Id.ToString()
                         || !ulong.TryParse(Constants.RegexConstants.discord_link_rx.Match(upTo).Groups[3].Value, out messageId)
                     )
-                    {
                     {
                         await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent($"{Program.cfgjson.Emoji.Error} Please provide a valid link to a message in this channel!").AsEphemeral(true));
                         return;
@@ -174,8 +173,8 @@
                 }
             }
 
-            // Images only
-            if (imagesOnly)
+            // Attachments only
+            if (attachmentsOnly)
             {
                 if (linksOnly)
                 {
@@ -204,7 +203,7 @@
                 }
             }
 
-           // Skip messages older than 2 weeks, since Discord won't let us delete them anyway
+            // Skip messages older than 2 weeks, since Discord won't let us delete them anyway
 
             bool skipped = false;
             foreach (var message in messagesToClear.ToList())

--- a/Commands/InteractionCommands/ClearInteractions.cs
+++ b/Commands/InteractionCommands/ClearInteractions.cs
@@ -1,0 +1,230 @@
+﻿namespace Cliptok.Commands.InteractionCommands
+{
+    public class ClearInteractions : ApplicationCommandModule
+    {
+        public static Dictionary<ulong, List<DiscordMessage>> MessagesToClear = new();
+
+        [SlashCommand("clear", "Delete many messages from the current channel.", defaultPermission: false)]
+        [HomeServer, SlashRequireHomeserverPerm(ServerPermLevel.TrialModerator), RequireBotPermissions(Permissions.ManageMessages), SlashCommandPermissions(Permissions.ModerateMembers)]
+        public async Task ClearSlashCommand(InteractionContext ctx,
+            [Option("count", "The number of messages to delete. Required if you don't use the 'upto' argument.")] long count = 0,
+            [Option("upto", "Optionally delete messages up to (not including) this one. Accepts IDs and links.")] string upTo = "",
+            [Option("user", "Optionally filter the deletion to a specific user.")] DiscordUser user = default,
+            [Option("ignoremods", "Optionally filter the deletion to only messages sent by users who are not Moderators.")] bool ignoreMods = false,
+            [Option("match", "Optionally filter the deletion to only messages containing certain text.")] string match = "",
+            [Option("botsonly", "Optionally filter the deletion to only bots.")] bool botsOnly = false,
+            [Option("humansonly", "Optionally filter the deletion to only humans.")] bool humansOnly = false,
+            [Option("imagesonly", "Optionally filter the deletion to only messages containing images.")] bool imagesOnly = false,
+            [Option("linksonly", "Optionally filter the deletion to only messages containing links.")] bool linksOnly = false
+        )
+        {
+            await ctx.CreateResponseAsync(InteractionResponseType.DeferredChannelMessageWithSource, new DiscordInteractionResponseBuilder().AsEphemeral(true));
+
+            // If all args are unset
+            if (count == 0 && upTo == "" && user == default && ignoreMods == false && match == "" && botsOnly == false && humansOnly == false && imagesOnly == false && linksOnly == false)
+            {
+                await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent($"{Program.cfgjson.Emoji.Error} You must provide at least one argument! I need to know which messages to delete.").AsEphemeral(true));
+                return;
+            }
+
+            // If count is too low or too high, refuse the request
+
+            if (count < 0)
+            {
+                await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent($"{Program.cfgjson.Emoji.Error} I can't delete a negative number of messages! Try setting `count` to a positive number.").AsEphemeral(true));
+            }
+
+            if (count >= 1000)
+            {
+                await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent($"{Program.cfgjson.Emoji.Error} Deleting that many messages poses a risk of something disastrous happening, so I'm refusing your request, sorry.").AsEphemeral(true));
+                return;
+            }
+
+            // Get messages to delete, whether that's messages up to a certain one or the last 'x' number of messages.
+
+            if (upTo != "" && count != 0)
+            {
+                await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent($"{Program.cfgjson.Emoji.Error} You can't provide both a count of messages and a message to delete up to! Please only provide one of the two arguments.").AsEphemeral(true));
+                return;
+            }
+
+            List<DiscordMessage> messagesToClear;
+            if (upTo == "")
+            {
+                var messages = await ctx.Channel.GetMessagesAsync((int)count);
+                messagesToClear = messages.ToList();
+            }
+            else
+            {
+                DiscordMessage message;
+                ulong messageId;
+                if (!upTo.Contains("discord.com"))
+                {
+                    try
+                    {
+                        messageId = Convert.ToUInt64(upTo);
+                    }
+                    catch
+                    {
+                        await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent($"{Program.cfgjson.Emoji.Error} That doesn't look like a valid message ID or link! Try again."));
+                        return;
+                    }
+                }
+                else
+                {
+                    // Extract all IDs from URL. This will leave you with something like "guild_id/channel_id/message_id".
+                    Regex extractIds = new(@".*.discord.com\/channels\/");
+                    Match selectionToRemove = extractIds.Match(upTo);
+                    upTo = upTo.Replace(selectionToRemove.ToString(), "");
+
+                    // Parse message ID, set to variable
+                    Regex getMessageId = new(@"[a-zA-Z0-9]*\/[a-zA-Z0-9]*\/");
+                    Match idsToRemove = getMessageId.Match(upTo);
+                    string targetMsgId = upTo.Replace(idsToRemove.ToString(), "");
+                    messageId = Convert.ToUInt64(targetMsgId.ToString());
+                }
+
+                // This is the message we will delete up to. This message will not be deleted.
+                message = await ctx.Channel.GetMessageAsync(messageId);
+
+                // List of messages to delete, up to (not including) the one we just got.
+                var messages = await ctx.Channel.GetMessagesAfterAsync(message.Id);
+                messagesToClear = messages.ToList();
+            }
+
+            // Now we know how many messages we'll be looking through and we won't be refusing the request. Time to check filters.
+            // Order of priority here is the order of the arguments for the command.
+
+            // Match user
+            if (user != default)
+            {
+                foreach (var message in messagesToClear.ToList())
+                {
+                    if (message.Author.Id != user.Id)
+                    {
+                        messagesToClear.Remove(message);
+                    }
+                }
+            }
+
+            // Ignore mods
+            if (ignoreMods)
+            {
+                foreach (var message in messagesToClear.ToList())
+                {
+                    DiscordMember member;
+                    try
+                    {
+                        member = await ctx.Guild.GetMemberAsync(message.Author.Id);
+                    }
+                    catch (DSharpPlus.Exceptions.NotFoundException)
+                    {
+                        // User is not in the server, assume not mod
+                        continue;
+                    }
+
+                    if (GetPermLevel(member) >= ServerPermLevel.TrialModerator)
+                    {
+                        messagesToClear.Remove(message);
+                    }
+                }
+            }
+
+            // Match text
+            if (match != "")
+            {
+                foreach (var message in messagesToClear.ToList())
+                {
+                    if (!message.Content.ToLower().Contains(match.ToLower()))
+                    {
+                        messagesToClear.Remove(message);
+                    }
+                }
+            }
+
+            // Bots only
+            if (botsOnly)
+            {
+                if (humansOnly)
+                {
+                    await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent($"{Program.cfgjson.Emoji.Error} You can't use `botsonly` and `humansonly` together! Pick one or the other please.").AsEphemeral(true));
+                    return;
+                }
+
+                foreach (var message in messagesToClear.ToList())
+                {
+                    if (!message.Author.IsBot)
+                    {
+                        messagesToClear.Remove(message);
+                    }
+                }
+            }
+
+            // Humans only
+            if (humansOnly)
+            {
+                foreach (var message in messagesToClear.ToList())
+                {
+                    if (message.Author.IsBot)
+                    {
+                        messagesToClear.Remove(message);
+                    }
+                }
+            }
+
+            // Images only
+            if (imagesOnly)
+            {
+                if (linksOnly)
+                {
+                    await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent($"{Program.cfgjson.Emoji.Error} You can't use `imagesonly` and `linksonly` together! Pick one or the other please.").AsEphemeral(true));
+                    return;
+                }
+
+                foreach (var message in messagesToClear.ToList())
+                {
+                    if (message.Attachments.Count == 0)
+                    {
+                        messagesToClear.Remove(message);
+                    }
+                }
+            }
+
+            // Links only
+            if (linksOnly)
+            {
+                foreach (var message in messagesToClear.ToList())
+                {
+                    if (!Constants.RegexConstants.url_rx.IsMatch(message.Content.ToLower()))
+                    {
+                        messagesToClear.Remove(message);
+                    }
+                }
+            }
+
+            // All filters checked. 'messages' is now our final list of messages to delete.
+
+            // Warn the mod if we're going to be deleting 50 or more messages.
+            if (messagesToClear.Count >= 1)
+            {
+                DiscordButtonComponent confirmButton = new(ButtonStyle.Danger, "button with weird id", "button with weird id");
+                DiscordMessage confirmationMessage = await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent($"{Program.cfgjson.Emoji.Muted} You're about to delete {messagesToClear.Count} messages. Are you sure?").AddComponents(confirmButton).AsEphemeral(true));
+
+                MessagesToClear.Add(confirmationMessage.Id, messagesToClear);
+            }
+            else
+            {
+                if (messagesToClear.Count >= 1)
+                {
+                    await ctx.Channel.DeleteMessagesAsync(messagesToClear);
+
+                    await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent($"{Program.cfgjson.Emoji.Success} Done!").AsEphemeral(true));
+                }
+                else
+                {
+                    await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent($"{Program.cfgjson.Emoji.Error} There were no messages that matched all of the arguments you provided! Nothing to do."));
+                }
+            }
+        }
+    }
+}

--- a/Commands/InteractionCommands/ClearInteractions.cs
+++ b/Commands/InteractionCommands/ClearInteractions.cs
@@ -205,9 +205,9 @@
             // All filters checked. 'messages' is now our final list of messages to delete.
 
             // Warn the mod if we're going to be deleting 50 or more messages.
-            if (messagesToClear.Count >= 1)
+            if (messagesToClear.Count >= 50)
             {
-                DiscordButtonComponent confirmButton = new(ButtonStyle.Danger, "button with weird id", "button with weird id");
+                DiscordButtonComponent confirmButton = new(ButtonStyle.Danger, "clear-confirm-callback", "Delete Messages");
                 DiscordMessage confirmationMessage = await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent($"{Program.cfgjson.Emoji.Muted} You're about to delete {messagesToClear.Count} messages. Are you sure?").AddComponents(confirmButton).AsEphemeral(true));
 
                 MessagesToClear.Add(confirmationMessage.Id, messagesToClear);

--- a/Commands/InteractionCommands/ClearInteractions.cs
+++ b/Commands/InteractionCommands/ClearInteractions.cs
@@ -32,6 +32,7 @@
             if (count < 0)
             {
                 await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent($"{Program.cfgjson.Emoji.Error} I can't delete a negative number of messages! Try setting `count` to a positive number.").AsEphemeral(true));
+                return;
             }
 
             if (count >= 1000)

--- a/Constants/RegexConstants.cs
+++ b/Constants/RegexConstants.cs
@@ -7,6 +7,7 @@
         readonly public static Regex invite_rx = new("(?:discord|discordapp)\\.(?:gg|com\\/invite)\\/([\\w+-]+)");
         readonly public static Regex url_rx = new("(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]");
         readonly public static Regex bold_rx = new("\\*\\*(.*?)\\*\\*");
+        readonly public static Regex discord_link_rx = new(@".*discord(?:app)?.com\/channels\/((?:@)?[a-z0-9]*)\/([0-9]*)(?:\/)?([0-9]*)");
 
     }
 }

--- a/Events/InteractionEvents.cs
+++ b/Events/InteractionEvents.cs
@@ -36,9 +36,15 @@ namespace Cliptok.Events
                 
                 List<DiscordMessage> messages = messagesToClear.GetValueOrDefault(e.Message.Id);
 
-                await e.Channel.DeleteMessagesAsync(messages);
+                await e.Channel.DeleteMessagesAsync(messages, $"[Clear by {e.User.Username}#{e.User.Discriminator}]");
 
                 DiscordButtonComponent disabledButton = new(ButtonStyle.Danger, "clear-confirm-callback", "Delete Messages", true);
+                await e.Channel.SendMessageAsync($"{cfgjson.Emoji.Deleted} Cleared **{messagesToClear.Count}** messages from {e.Channel.Mention}!");
+                await LogChannelHelper.LogMessageAsync("mod",
+                    new DiscordMessageBuilder()
+                        .WithContent($"{cfgjson.Emoji.Deleted} **{messagesToClear.Count}** messages were cleared in {e.Channel.Mention} by {e.User.Mention}.")
+                        .WithAllowedMentions(Mentions.None)
+                );
                 e.Interaction.CreateResponseAsync(InteractionResponseType.UpdateMessage, new DiscordInteractionResponseBuilder().WithContent($"{cfgjson.Emoji.Success} Done!").AddComponents(disabledButton).AsEphemeral(true));
             }
             else

--- a/Events/InteractionEvents.cs
+++ b/Events/InteractionEvents.cs
@@ -76,8 +76,8 @@ namespace Cliptok.Events
                             );
                     }
             }
+            e.Context.Client.Logger.LogError(CliptokEventID, e.Exception, "Error during invocation of interaction command {command} by {user}", e.Context.CommandName, $"{e.Context.User.Username}#{e.Context.User.Discriminator}");
         }
-
 
     }
 }


### PR DESCRIPTION
This PR closes #140.

Adds a `/clear` command with multiple arguments to narrow down which messages should be deleted. Only one is required though - either `count` to specify the number of messages to delete, or `upto` to specify a message to delete "up to" (not including that message!). All others are optional.

Some arguments, like `humansonly` (delete only messages sent by humans) and `botsonly` (delete only messages sent by bots) are obviously not compatible with each other, and the bot will return an error message if they are used together. This also applies to using `count` and `upto` together, as you should specify either a number of messages to delete OR a message to delete up to (the count doesn't matter here, all messages up to that one are deleted) - they don't work together. Same for `imagesonly` and `linksonly`.