### PR TITLE
Fixes/improvements to /clear

### DIFF
--- a/Commands/InteractionCommands/ClearInteractions.cs
+++ b/Commands/InteractionCommands/ClearInteractions.cs
@@ -55,7 +55,7 @@
                 return;
             }
 
-            List<DiscordMessage> messagesToClear;
+            List<DiscordMessage> messagesToClear = new();
             if (upTo == "")
             {
                 var messages = await ctx.Channel.GetMessagesAsync((int)count);
@@ -89,8 +89,17 @@
                 message = await ctx.Channel.GetMessageAsync(messageId);
 
                 // List of messages to delete, up to (not including) the one we just got.
-                var messages = await ctx.Channel.GetMessagesAfterAsync(message.Id);
-                messagesToClear = messages.ToList();
+                var firstMsg = (await ctx.Channel.GetMessagesAfterAsync(message.Id, 1))[0];
+                var firstMsgId = firstMsg.Id;
+                messagesToClear.Add(firstMsg);
+                while (true)
+                {
+                    var newMessages = (await ctx.Channel.GetMessagesAfterAsync(firstMsgId, 100)).ToList();
+                    messagesToClear.AddRange(newMessages);
+                    firstMsgId = newMessages.First().Id;
+                    if (newMessages.Count < 100)
+                        break;
+                }
             }
 
             // Now we know how many messages we'll be looking through and we won't be refusing the request. Time to check filters.

--- a/Events/InteractionEvents.cs
+++ b/Events/InteractionEvents.cs
@@ -32,28 +32,31 @@ namespace Cliptok.Events
             }
             else if (e.Id == "clear-confirm-callback")
             {
-                Dictionary<ulong, List<DiscordMessage>> messagesToClear = Commands.InteractionCommands.ClearInteractions.MessagesToClear;
+                Task.Run(async () =>
+                {
+                    Dictionary<ulong, List<DiscordMessage>> messagesToClear = Commands.InteractionCommands.ClearInteractions.MessagesToClear;
 
-                List<DiscordMessage> messages = messagesToClear.GetValueOrDefault(e.Message.Id);
+                    List<DiscordMessage> messages = messagesToClear.GetValueOrDefault(e.Message.Id);
 
-                await e.Channel.DeleteMessagesAsync(messages, $"[Clear by {e.User.Username}#{e.User.Discriminator}]");
+                    await e.Channel.DeleteMessagesAsync(messages, $"[Clear by {e.User.Username}#{e.User.Discriminator}]");
 
-                DiscordButtonComponent disabledButton = new(ButtonStyle.Danger, "clear-confirm-callback", "Delete Messages", true);
-                await e.Channel.SendMessageAsync($"{cfgjson.Emoji.Deleted} Cleared **{messagesToClear.Count}** messages from {e.Channel.Mention}!");
-                await LogChannelHelper.LogMessageAsync("mod",
-                    new DiscordMessageBuilder()
-                        .WithContent($"{cfgjson.Emoji.Deleted} **{messagesToClear.Count}** messages were cleared in {e.Channel.Mention} by {e.User.Mention}.")
-                        .WithAllowedMentions(Mentions.None)
-                );
+                    DiscordButtonComponent disabledButton = new(ButtonStyle.Danger, "clear-confirm-callback", "Delete Messages", true);
+                    await e.Channel.SendMessageAsync($"{cfgjson.Emoji.Deleted} Cleared **{messages.Count}** messages from {e.Channel.Mention}!");
+                    await LogChannelHelper.LogMessageAsync("mod",
+                        new DiscordMessageBuilder()
+                            .WithContent($"{cfgjson.Emoji.Deleted} **{messages.Count}** messages were cleared in {e.Channel.Mention} by {e.User.Mention}.")
+                            .WithAllowedMentions(Mentions.None)
+                    );
 
-                await LogChannelHelper.LogDeletedMessagesAsync(
-                    "messages",
-                    $"{cfgjson.Emoji.Deleted} **{messages.Count}** messages were cleared from {e.Channel.Mention} by {e.User.Mention}.",
-                    messages,
-                    e.Channel
-                );
+                    await LogChannelHelper.LogDeletedMessagesAsync(
+                        "messages",
+                        $"{cfgjson.Emoji.Deleted} **{messages.Count}** messages were cleared from {e.Channel.Mention} by {e.User.Mention}.",
+                        messages,
+                        e.Channel
+                    );
 
-                e.Interaction.CreateResponseAsync(InteractionResponseType.UpdateMessage, new DiscordInteractionResponseBuilder().WithContent($"{cfgjson.Emoji.Success} Done!").AddComponents(disabledButton).AsEphemeral(true));
+                    e.Interaction.CreateResponseAsync(InteractionResponseType.UpdateMessage, new DiscordInteractionResponseBuilder().WithContent($"{cfgjson.Emoji.Success} Done!").AddComponents(disabledButton).AsEphemeral(true));
+                });
             }
             else
             {

--- a/Events/InteractionEvents.cs
+++ b/Events/InteractionEvents.cs
@@ -36,12 +36,19 @@ namespace Cliptok.Events
                 {
                     Dictionary<ulong, List<DiscordMessage>> messagesToClear = Commands.InteractionCommands.ClearInteractions.MessagesToClear;
 
+                    if (!messagesToClear.ContainsKey(e.Message.Id))
+                    {
+                        await e.Interaction.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource,
+                            new DiscordInteractionResponseBuilder().WithContent($"{cfgjson.Emoji.Error} These messages have already been deleted!").AsEphemeral(true));
+                        return;
+                    }
+
+                    await e.Interaction.CreateResponseAsync(InteractionResponseType.DeferredChannelMessageWithSource, new DiscordInteractionResponseBuilder().AsEphemeral(true));
+
                     List<DiscordMessage> messages = messagesToClear.GetValueOrDefault(e.Message.Id);
 
                     await e.Channel.DeleteMessagesAsync(messages, $"[Clear by {e.User.Username}#{e.User.Discriminator}]");
 
-                    DiscordButtonComponent disabledButton = new(ButtonStyle.Danger, "clear-confirm-callback", "Delete Messages", true);
-                    await e.Channel.SendMessageAsync($"{cfgjson.Emoji.Deleted} Cleared **{messages.Count}** messages from {e.Channel.Mention}!");
                     await LogChannelHelper.LogMessageAsync("mod",
                         new DiscordMessageBuilder()
                             .WithContent($"{cfgjson.Emoji.Deleted} **{messages.Count}** messages were cleared in {e.Channel.Mention} by {e.User.Mention}.")
@@ -55,7 +62,11 @@ namespace Cliptok.Events
                         e.Channel
                     );
 
-                    e.Interaction.CreateResponseAsync(InteractionResponseType.UpdateMessage, new DiscordInteractionResponseBuilder().WithContent($"{cfgjson.Emoji.Success} Done!").AddComponents(disabledButton).AsEphemeral(true));
+                    messagesToClear.Remove(e.Message.Id);
+
+                    await e.Channel.SendMessageAsync($"{cfgjson.Emoji.Deleted} Cleared **{messages.Count}** messages from {e.Channel.Mention}!");
+
+                    await e.Interaction.CreateFollowupMessageAsync(new DiscordFollowupMessageBuilder().WithContent($"{cfgjson.Emoji.Success} Done!").AsEphemeral(true));
                 });
             }
             else


### PR DESCRIPTION
- Use an async task for the interaction event triggered by the "Delete Messages" button if the number of messages to delete is >50. This prevents `An event handler for COMPONENT_INTERACTED took too long to execute` warnings. 
- The response to the interaction event triggered by the "Delete Messages" button is now deferred to prevent timeouts. 
- When using the `up_to` argument, the bot will no longer fail to delete more than 100 messages (previously it would delete only 100 and leave the rest). 
- The count of messages deleted is now correct. Previously it would be very wrong if you were deleting over 50 messages. 