### PR TITLE
Add !permadehoist & /permadehoist

### DIFF
--- a/Commands/InteractionCommands/DehoistInteractions.cs
+++ b/Commands/InteractionCommands/DehoistInteractions.cs
@@ -1,0 +1,49 @@
+﻿namespace Cliptok.Commands.InteractionCommands
+{
+    internal class DehoistInteractions : ApplicationCommandModule
+    {
+        [SlashCommandGroup("permadehoist", "Permanently/persistently dehoist members.", defaultPermission: false)]
+        [HomeServer, SlashRequireHomeserverPerm(ServerPermLevel.TrialModerator)]
+        public class PermadehoistSlashCommands
+        {
+            [SlashCommand("enable", "Permanently dehoist a member. They will be automatically dehoisted until disabled.")]
+            public async Task PermadehoistEnableSlashCmd(InteractionContext ctx, [Option("member", "The member to permadehoist.")] DiscordUser discordUser)
+            {
+                var (success, isPermissionError) = await DehoistHelpers.PermadehoistMember(discordUser, ctx.User, ctx.Guild);
+
+                if (success)
+                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.On} Successfully permadehoisted {discordUser.Mention}!", mentions: false);
+
+                if (!success & !isPermissionError)
+                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} {discordUser.Mention} is already permadehoisted!", mentions: false);
+
+                if (!success && isPermissionError)
+                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} Failed to permadehoist {discordUser.Mention}!", mentions: false);
+            }
+
+            [SlashCommand("disable", "Disable permadehoist for a member.")]
+            public async Task PermadehoistDisableSlashCmd(InteractionContext ctx, [Option("member", "The member to remove the permadehoist for.")] DiscordUser discordUser)
+            {
+                var (success, isPermissionError) = await DehoistHelpers.UnpermadehoistMember(discordUser, ctx.User, ctx.Guild);
+
+                if (success)
+                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.On} Successfully removed the permadehoist for {discordUser.Mention}!", mentions: false);
+
+                if (!success & !isPermissionError)
+                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} {discordUser.Mention} isn't permadehoisted!", mentions: false);
+
+                if (!success && isPermissionError)
+                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} Failed to remove the permadehoist for {discordUser.Mention}!", mentions: false);
+            }
+
+            [SlashCommand("status", "Check the status of permadehoist for a member.")]
+            public async Task PermadehoistStatusSlashCmd(InteractionContext ctx, [Option("member", "The member whose permadehoist status to check.")] DiscordUser discordUser)
+            {
+                if (await Program.db.SetContainsAsync("permadehoists", discordUser.Id))
+                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.On} {discordUser.Mention} is permadehoisted.", mentions: false);
+                else
+                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Off} {discordUser.Mention} is not permadehoisted.", mentions: false);
+            }
+        }
+    }
+}

--- a/Events/MemberEvents.cs
+++ b/Events/MemberEvents.cs
@@ -193,6 +193,16 @@ namespace Cliptok.Events
                     db.HashDeleteAsync("mutes", e.Member.Id);
 
                 DehoistHelpers.CheckAndDehoistMemberAsync(e.Member);
+
+                // Persist permadehoists
+                if (await db.SetContainsAsync("permadehoists", e.Member.Id))
+                    if (e.Member.DisplayName[0] != DehoistHelpers.dehoistCharacter)
+                        // Member is in permadehoist list. Dehoist.
+                        e.Member.ModifyAsync(a =>
+                        {
+                            a.Nickname = DehoistHelpers.DehoistName(e.Member.DisplayName);
+                            a.AuditLogReason = "[Automatic dehoist; user is permadehoisted]";
+                        });
             }
             );
         }

--- a/Helpers/DehoistHelpers.cs
+++ b/Helpers/DehoistHelpers.cs
@@ -13,7 +13,7 @@
             return dehoistCharacter + origName;
         }
 
-        public static async Task<bool> CheckAndDehoistMemberAsync(DiscordMember targetMember)
+        public static async Task<bool> CheckAndDehoistMemberAsync(DiscordMember targetMember, DiscordUser responsibleMod = default, bool isMassDehoist = false)
         {
 
             if (
@@ -33,13 +33,117 @@
                 await targetMember.ModifyAsync(a =>
                 {
                     a.Nickname = DehoistName(targetMember.DisplayName);
-                    a.AuditLogReason = "Dehoisted";
+                    a.AuditLogReason = responsibleMod != default ? isMassDehoist ? $"[Mass dehoist by {responsibleMod.Username}#{responsibleMod.Discriminator}]" : $"[Dehoist by {responsibleMod.Username}#{responsibleMod.Discriminator}]" : "[Automatic dehoist]";
                 });
                 return true;
             }
             catch
             {
                 return false;
+            }
+        }
+
+        public static async Task<(bool success, bool isPermissionError)> PermadehoistMember(DiscordUser discordUser, DiscordUser responsibleMod, DiscordGuild guild)
+        {
+            // If member is already in permadehoist list, fail
+            if (await Program.db.SetContainsAsync("permadehoists", discordUser.Id))
+                return (false, false);
+
+            // Add member ID to permadehoist list
+            await Program.db.SetAddAsync("permadehoists", discordUser.Id);
+
+            if (guild is not null)
+            {
+                DiscordMember discordMember;
+                try
+                {
+                    discordMember = await guild.GetMemberAsync(discordUser.Id);
+                }
+                catch
+                {
+                    return (true, false);
+                }
+
+                // If member is dehoisted already, but NOT permadehoisted, skip updating nickname.
+
+                if (discordMember.Nickname is null || discordMember.Nickname[0] != dehoistCharacter)
+                {
+                    // Dehoist member
+                    try
+                    {
+                        await discordMember.ModifyAsync(a =>
+                        {
+                            a.Nickname = DehoistName(discordMember.DisplayName);
+                            a.AuditLogReason =
+                                $"[Permadehoist by {responsibleMod.Username}#{responsibleMod.Discriminator}]";
+                        });
+                    }
+                    catch
+                    {
+                        return (false, true);
+                    }
+                }
+            }
+
+            return (true, false);
+        }
+
+        public static async Task<(bool success, bool isPermissionError)> UnpermadehoistMember(DiscordUser discordUser, DiscordUser responsibleMod, DiscordGuild guild)
+        {
+            // If member is not dehoisted and is not in permadehoist list, fail
+            if (!await Program.db.SetContainsAsync("permadehoists", discordUser.Id))
+                return (false, false);
+
+            // Remove member ID from permadehoist list
+            await Program.db.SetRemoveAsync("permadehoists", discordUser.Id);
+
+            if (guild is not null)
+            {
+                DiscordMember discordMember;
+                try
+                {
+                    discordMember = await guild.GetMemberAsync(discordUser.Id);
+                }
+                catch
+                {
+                    return (true, false);
+                }
+
+                // Un-dehoist member
+                if (discordMember.DisplayName[0] == dehoistCharacter)
+                {
+                    var newNickname = discordMember.DisplayName[1..];
+                    try
+                    {
+                        await discordMember.ModifyAsync(a =>
+                        {
+                            a.Nickname = newNickname;
+                            a.AuditLogReason = $"[Permadehoist removed by {responsibleMod.Username}#{responsibleMod.Discriminator}]";
+                        });
+                    }
+                    catch
+                    {
+                        return (false, true);
+                    }
+                }
+            }
+
+            return (true, false);
+        }
+
+        public static async Task<(bool success, bool isPermissionError, bool isDehoist)> TogglePermadehoist(DiscordUser discordUser, DiscordUser responsibleMod, DiscordGuild guild)
+        {
+            if (await Program.db.SetContainsAsync("permadehoists", discordUser.Id))
+            {
+                // Member is dehoisted; un-permadehoist
+                var (success, isPermissionError) = await UnpermadehoistMember(discordUser, responsibleMod, guild);
+                return (success, isPermissionError, false);
+            }
+            else
+            {
+                // Member is not permadehoisted; permadehoist
+                var (success, isPermissionError) = await PermadehoistMember(discordUser, responsibleMod, guild);
+                return (success, isPermissionError, true);
             }
         }
     }

--- a/Helpers/InteractionHelpers.cs
+++ b/Helpers/InteractionHelpers.cs
@@ -7,7 +7,7 @@
             await ctx.CreateResponseAsync(InteractionResponseType.DeferredChannelMessageWithSource);
         }
 
-        public static async Task RespondAsync(this BaseContext ctx, string text = null, DiscordEmbed embed = null, bool ephemeral = false, params DiscordComponent[] components)
+        public static async Task RespondAsync(this BaseContext ctx, string text = null, DiscordEmbed embed = null, bool ephemeral = false, bool mentions = true, params DiscordComponent[] components)
         {
             DiscordInteractionResponseBuilder response = new();
 
@@ -16,8 +16,7 @@
             if (components.Length != 0) response.AddComponents(components);
 
             response.AsEphemeral(ephemeral);
-
-            response.AddMentions(Mentions.All);
+            response.AddMentions(mentions ? Mentions.All : Mentions.None);
 
             await ctx.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource, response);
         }


### PR DESCRIPTION
This PR closes #154.

Adds `!permadehoist` & `/permadehoist` - a set of commands that can be used to permanently/persistently dehoist users (until disabled).

Also adds:
- Audit Log reasons for regular dehoists (`!dehoist`, `!massdehoist`, `!massundehoist`)
- Two optional arguments to `Helpers.DehoistHelpers.CheckAndDehoistMemberAsync` for Audit Log reasons: `DiscordUser responsibleMod` & `bool isMassDehoist`
- Optional `bool mentions` argument to `Helpers.BaseContextExtensions.RespondAsync` to allow responses with mentions disabled