### PR TITLE
Automatically respond to replies to punishment DMs

### DIFF
--- a/Events/DirectMessageEvent.cs
+++ b/Events/DirectMessageEvent.cs
@@ -4,7 +4,32 @@
     {
         public static async void DirectMessageEventHandler(DiscordMessage message)
         {
-            await LogChannelHelper.LogMessageAsync("dms", await DiscordHelpers.GenerateMessageRelay(message));
+            // Auto-response to contact modmail if DM follows warn/mute and is within configured time limit
+
+            bool sentAutoresponse = false;
+            
+            // Ignore messages older than time limit (in hours)
+            if ((DateTime.UtcNow - message.CreationTimestamp.DateTime).TotalHours < Program.cfgjson.DmAutoresponseTimeLimit)
+            {
+                // Make sure there is a message before the current one, otherwise an exception could be thrown
+                var msgBefore = await message.Channel.GetMessagesBeforeAsync(message.Id, 1);
+                if (msgBefore.Count > 0)
+                {
+                    // Make sure the message before the current one is from the bot and is a warn/mute DM & respond
+                    if (msgBefore[0].Author.Id == Program.discord.CurrentUser.Id &&
+                        (msgBefore[0].Content.Contains("You were warned") ||
+                         msgBefore[0].Content.Contains("You have been muted")))
+                    {
+                        await message.RespondAsync(
+                            "You can discuss warnings and punishments with the moderators by messaging modmail:" +
+                            $" <@{Program.cfgjson.ModmailUserId}>");
+                        sentAutoresponse = true;
+                    }
+                }
+            }
+
+            // Log DMs to DM log channel, include note about auto-response if applicable
+            await LogChannelHelper.LogMessageAsync("dms", await DiscordHelpers.GenerateMessageRelay(message, sentAutoresponse: sentAutoresponse));
         }
     }
 }

--- a/Events/DirectMessageEvent.cs
+++ b/Events/DirectMessageEvent.cs
@@ -18,10 +18,11 @@
                     // Make sure the message before the current one is from the bot and is a warn/mute DM & respond
                     if (msgBefore[0].Author.Id == Program.discord.CurrentUser.Id &&
                         (msgBefore[0].Content.Contains("You were warned") ||
-                         msgBefore[0].Content.Contains("You have been muted")))
+                         msgBefore[0].Content.Contains("You have been muted") ||
+                         msgBefore[0].Content.Contains("You were automatically warned")))
                     {
                         await message.RespondAsync(
-                            "You can discuss warnings and punishments with the moderators by messaging modmail:" +
+                            $"{Program.cfgjson.Emoji.Information} If you wish to discuss moderator actions, **please contact**" +
                             $" <@{Program.cfgjson.ModmailUserId}>");
                         sentAutoresponse = true;
                     }

--- a/Helpers/DiscordHelpers.cs
+++ b/Helpers/DiscordHelpers.cs
@@ -158,7 +158,7 @@
             return embed.Build();
         }
 
-        public static async Task<DiscordMessageBuilder> GenerateMessageRelay(DiscordMessage message, bool jumplink = false, bool channelRef = false, bool showChannelId = true)
+        public static async Task<DiscordMessageBuilder> GenerateMessageRelay(DiscordMessage message, bool jumplink = false, bool channelRef = false, bool showChannelId = true, bool sentAutoresponse = false)
         {
             DiscordEmbedBuilder embed = new DiscordEmbedBuilder()
                 .WithAuthor($"{message.Author.Username}#{message.Author.Discriminator}{(channelRef ? $" in #{message.Channel.Name}" : "")}", null, message.Author.AvatarUrl)
@@ -196,6 +196,11 @@
             {
                 embed.WithTitle($"Replying to {message.ReferencedMessage.Author.Username}")
                     .WithUrl(MessageLink(message.ReferencedMessage));
+            }
+
+            if (sentAutoresponse)
+            {
+                embed.Footer.Text += "\nThis DM triggered an autoresponse.";
             }
 
             List<DiscordEmbed> embeds = new()

--- a/Structs.cs
+++ b/Structs.cs
@@ -278,6 +278,9 @@
 
         [JsonProperty("insiderCommandLockedToChannel")]
         public ulong InsiderCommandLockedToChannel { get; private set; } = 0;
+
+        [JsonProperty("dmAutoresponseTimeLimit")]
+        public int DmAutoresponseTimeLimit { get; private set; } = 0;
     }
 
     public class LogChannelConfig

--- a/config.json
+++ b/config.json
@@ -313,5 +313,6 @@
     1065659890036646019
   ],
   "insiderAnnouncementChannel": 1043898319883219004,
-  "insiderCommandLockedToChannel": 187649467611086849
+  "insiderCommandLockedToChannel": 187649467611086849,
+  "dmAutoresponseTimeLimit": 0
 }


### PR DESCRIPTION
This PR closes #166.

Cliptok will automatically respond to messages that immediately follow a warn or mute DM from the bot. Messages are only responded to if the age of the warn/mute DM is less than `dmAutoresponseTimeLimit` hours in `config.json`. When this value is `0`, no messages are responded to automatically (this is the current state, I left it at 0 for now).

There are no restrictions on the content of the user's message; any message will be responded to as long as it directly follows a warn or mute DM within `dmAutoresponseTimeLimit` hours.

Example:
![mgPzVhMQrn](https://user-images.githubusercontent.com/51096169/220240803-d1bbcef4-aec7-4273-acd7-42f2b92e8d19.png)

When a user's DM is forwarded to Cliptok's DM log channel, a note is included if the message triggered this autoresponse. Example:
![CMq5sau0r0](https://user-images.githubusercontent.com/51096169/220241403-fc15d746-0f70-4322-b914-0296aa7d55b0.png)