### PR TITLE
Catch exception in thread auto-delete

### DIFF
--- a/Events/MessageEvent.cs
+++ b/Events/MessageEvent.cs
@@ -27,9 +27,17 @@ namespace Cliptok.Events
             // Delete thread if all messages are deleted
             if (Program.cfgjson.AutoDeleteEmptyThreads && e.Channel is DiscordThreadChannel)
             {
-                var member = await e.Guild.GetMemberAsync(e.Message.Author.Id);
-                if (GetPermLevel(member) >= ServerPermLevel.TrialModerator)
-                    return;
+                try
+                {
+                    var member = await e.Guild.GetMemberAsync(e.Message.Author.Id);
+                    if (GetPermLevel(member) >= ServerPermLevel.TrialModerator)
+                        return;
+                }
+                catch
+                {
+                    // User is not in the server. Assume they are not a moderator,
+                    // so do nothing here.
+                }
 
                 var messages = await e.Channel.GetMessagesAsync(1);
                 if (messages.Count == 0)


### PR DESCRIPTION
Fixes a bug in #171 where, if a message is deleted and its author is no longer in the server, the bot would throw an exception because it could not fetch the guild member to check whether they are a moderator.

This change adds a try/catch so that if the guild member cannot be fetched, we just assume they are not a moderator.