### PR TITLE
Make permadehoist actually work

### DIFF
--- a/Commands/InteractionCommands/DehoistInteractions.cs
+++ b/Commands/InteractionCommands/DehoistInteractions.cs
@@ -63,7 +63,7 @@
                 var (success, isPermissionError) = await DehoistHelpers.UnpermadehoistMember(discordUser, ctx.User, ctx.Guild);
 
                 if (success)
-                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.On} Successfully removed the permadehoist for {discordUser.Mention}!", mentions: false);
+                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Off} Successfully removed the permadehoist for {discordUser.Mention}!", mentions: false);
 
                 if (!success & !isPermissionError)
                     await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} {discordUser.Mention} isn't permadehoisted!", mentions: false);

--- a/Helpers/DehoistHelpers.cs
+++ b/Helpers/DehoistHelpers.cs
@@ -73,6 +73,7 @@
 
             // If member is dehoisted already, but NOT permadehoisted, skip updating nickname.
 
+            // If member is not dehoisted
             if (discordMember.DisplayName[0] != dehoistCharacter)
             {
                 // Dehoist member
@@ -91,12 +92,15 @@
                 }
                 catch
                 {
-                    // Add member ID to permadehoist list
+                    // On failure, add member ID to permadehoist list anyway
                     await Program.db.SetAddAsync("permadehoists", discordUser.Id);
 
                     return (false, false);
                 }
             }
+
+            // On success or if member is already dehoisted, just add member ID to permadehoist list
+            await Program.db.SetAddAsync("permadehoists", discordUser.Id);
 
             return (true, false);
         }


### PR DESCRIPTION
Fixes a critical issue with permadehoist where the user's ID was never added to the `permadehoists` set in redis. This would result in the bot responding with "successfully permadehoisted" even though the member would not actually be automatically dehoisted in the future if they changed their nickname to remove the dehoist character.