### PR TITLE
Add ability to store notes for joinwatched users

### DIFF
--- a/Commands/Lists.cs
+++ b/Commands/Lists.cs
@@ -182,20 +182,34 @@
         [HomeServer, RequireHomeserverPerm(ServerPermLevel.TrialModerator)]
         public async Task JoinWatch(
             CommandContext ctx,
-            [Description("The user to watch for joins and leaves of.")] DiscordUser user
+            [Description("The user to watch for joins and leaves of.")] DiscordUser user,
+            [Description("An optional note for context."), RemainingText] string note = ""
         )
         {
             var joinWatchlist = await Program.db.ListRangeAsync("joinWatchedUsers");
 
             if (joinWatchlist.Contains(user.Id))
             {
+                if (note != "")
+                {
+                    // User is already joinwatched, just update note
+                    await Program.db.HashSetAsync("joinWatchedUsersNotes", user.Id, note);
+                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Successfully updated the note for {user.Mention}. Run again with no note to unwatch.");
+                    return;
+                }
+
+                // User is already joinwatched, unwatch
                 Program.db.ListRemove("joinWatchedUsers", joinWatchlist.First(x => x == user.Id));
+                await Program.db.HashDeleteAsync("joinWatchedUsersNotes", user.Id);
                 await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Successfully unwatched {user.Mention}, since they were already in the list.");
             }
             else
             {
+                // User is not joinwatched, watch
                 await Program.db.ListRightPushAsync("joinWatchedUsers", user.Id);
-                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Now watching for joins/leaves of {user.Mention} to send to the investigations channel!");
+                await Program.db.HashSetAsync("joinWatchedUsersNotes", user.Id, note);
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Now watching for joins/leaves of {user.Mention} to send to the investigations channel"
+                    + (note == "" ? "!" : $" with the following note:\n>>> {note}"));
             }
         }
 

--- a/Events/MemberEvents.cs
+++ b/Events/MemberEvents.cs
@@ -29,6 +29,11 @@ namespace Cliptok.Events
 
             if (joinWatchlist.Contains(e.Member.Id))
             {
+                if (await db.HashExistsAsync("joinWatchedUsersNotes", e.Member.Id))
+                {
+                    embed.AddField($"Joinwatch Note", await db.HashGetAsync("joinWatchedUsersNotes", e.Member.Id));
+                }
+
                 LogChannelHelper.LogMessageAsync("investigations", $"{cfgjson.Emoji.Warning} Watched user {e.Member.Mention} just joined the server!", embed);
             }
 
@@ -176,6 +181,11 @@ namespace Cliptok.Events
 
             if (joinWatchlist.Contains(e.Member.Id))
             {
+                if (await db.HashExistsAsync("joinWatchedUsersNotes", e.Member.Id))
+                {
+                    embed.AddField($"Joinwatch Note", await db.HashGetAsync("joinWatchedUsersNotes", e.Member.Id));
+                }
+
                 LogChannelHelper.LogMessageAsync("investigations", $"{cfgjson.Emoji.Warning} Watched user {e.Member.Mention} just left the server!", embed);
             }
         }


### PR DESCRIPTION
Closes #177. Allows notes to be provided when joinwatching a user (`!joinwatch <user> [note]`). Command can be re-run in the same format for an already-joinwatched user to update their note, or run without a note to either joinwatch without a note or unwatch, depending on current status.