### PR TITLE
Add DM relay blocking functionality

### DIFF
--- a/Commands/DmRelayBlock.cs
+++ b/Commands/DmRelayBlock.cs
@@ -1,0 +1,28 @@
+﻿namespace Cliptok.Commands
+{
+    internal class DmRelayBlock : BaseCommandModule
+    {
+        [Command("dmrelayblock")]
+        [Description("Stop a member's DMs from being relayed to the configured DM relay channel.")]
+        [Aliases("dmblock")]
+        [HomeServer, RequireHomeserverPerm(ServerPermLevel.TrialModerator)]
+        public async Task DmRelayBlockCommand(CommandContext ctx, [Description("The member to stop relaying DMs from.")] DiscordUser user)
+        {
+            // Only function in configured DM relay channel/thread; do nothing if in wrong channel
+            if (ctx.Channel.Id != Program.cfgjson.DmLogChannelId && Program.cfgjson.LogChannels.All(a => a.Value.ChannelId != ctx.Channel.Id)) return;
+
+            // Check blocklist for user
+            if (await Program.db.SetContainsAsync("dmRelayBlocklist", user.Id))
+            {
+                // If already in list, remove
+                await Program.db.SetRemoveAsync("dmRelayBlocklist", user.Id);
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} {user.Mention} has been unblocked successfully!");
+                return;
+            }
+
+            // If not in list, add
+            await Program.db.SetAddAsync("dmRelayBlocklist", user.Id);
+            await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} {user.Mention} has been blocked. Their DMs will not appear here.");
+        }
+    }
+}

--- a/Events/DirectMessageEvent.cs
+++ b/Events/DirectMessageEvent.cs
@@ -4,6 +4,9 @@
     {
         public static async void DirectMessageEventHandler(DiscordMessage message)
         {
+            // Ignore message if user is blocked
+            if (await Program.db.SetContainsAsync("dmRelayBlocklist", message.Author.Id)) return;
+
             // Auto-response to contact modmail if DM follows warn/mute and is within configured time limit
 
             bool sentAutoresponse = false;


### PR DESCRIPTION
Closes #180. Allows mods to "block" users from Cliptok's DM relay with `!dmrelayblock` or `!dmblock` (users can still DM the bot, but messages will not be relayed to the DM log channel).