### PR TITLE
Add !tqsmute and /tqsmute

### DIFF
--- a/CommandChecks/HomeServerPerms.cs
+++ b/CommandChecks/HomeServerPerms.cs
@@ -1,6 +1,4 @@
-﻿using System.Formats.Tar;
-
-namespace Cliptok.CommandChecks
+﻿namespace Cliptok.CommandChecks
 {
     public class ServerPerms
     {

--- a/CommandChecks/HomeServerPerms.cs
+++ b/CommandChecks/HomeServerPerms.cs
@@ -1,4 +1,6 @@
-﻿namespace Cliptok.CommandChecks
+﻿using System.Formats.Tar;
+
+namespace Cliptok.CommandChecks
 {
     public class ServerPerms
     {
@@ -16,6 +18,7 @@
             Tier8,
             TierS,
             TierX,
+            TechnicalQueriesSlayer,
             TrialModerator,
             Moderator,
             Admin,
@@ -38,6 +41,8 @@
                 return ServerPermLevel.Muted;
             else if (target.Roles.Contains(target.Guild.GetRole(Program.cfgjson.TrialModRole)))
                 return ServerPermLevel.TrialModerator;
+            else if (target.Roles.Contains(target.Guild.GetRole(Program.cfgjson.TqsRoleId)))
+                return ServerPermLevel.TechnicalQueriesSlayer;
             else if (target.Roles.Contains(target.Guild.GetRole(Program.cfgjson.TierRoles[9])))
                 return ServerPermLevel.TierX;
             else if (target.Roles.Contains(target.Guild.GetRole(Program.cfgjson.TierRoles[8])))

--- a/Commands/InteractionCommands/MuteInteractions.cs
+++ b/Commands/InteractionCommands/MuteInteractions.cs
@@ -95,7 +95,7 @@
         public async Task TqsMuteSlashCommand(
             InteractionContext ctx,
             [Option("user", "The user to mute.")] DiscordUser targetUser,
-            [Option("reason", "The reason for the mute.")] string reason = "No reason specified.")
+            [Option("reason", "The reason for the mute.")] string reason)
         {
             await ctx.DeferAsync(ephemeral: true);
             

--- a/Commands/InteractionCommands/MuteInteractions.cs
+++ b/Commands/InteractionCommands/MuteInteractions.cs
@@ -95,7 +95,7 @@
         public async Task TqsMuteSlashCommand(
             InteractionContext ctx,
             [Option("user", "The user to mute.")] DiscordUser targetUser,
-            [Option("reason", "The reason for the mute.")] string reason)
+            [Option("reason", "The reason for the mute.")] string reason = "No reason specified.")
         {
             await ctx.DeferAsync(ephemeral: true);
             

--- a/Commands/InteractionCommands/MuteInteractions.cs
+++ b/Commands/InteractionCommands/MuteInteractions.cs
@@ -109,6 +109,18 @@
                 return;
             }
             
+            // Check if the user is already muted; disallow TQS-mute if so
+            
+            DiscordRole mutedRole = ctx.Guild.GetRole(Program.cfgjson.MutedRole);
+            DiscordRole tqsMutedRole = ctx.Guild.GetRole(Program.cfgjson.TqsMutedRole);
+            
+            if (await Program.db.HashExistsAsync("mutes", targetUser.Id) || ctx.Member.Roles.Contains(mutedRole) || ctx.Member.Roles.Contains(tqsMutedRole))
+            {
+                await ctx.EditResponseAsync(new DiscordWebhookBuilder().WithContent($"{Program.cfgjson.Emoji.Error} {ctx.User.Mention}, that user is already muted."));
+                return;
+            }
+            
+            // Get member
             DiscordMember targetMember = default;
             try
             {
@@ -119,6 +131,7 @@
                 // blah
             }
 
+            // Check if user to be muted is staff or TQS, and disallow if so
             if (targetMember != default && GetPermLevel(ctx.Member) == ServerPermLevel.TechnicalQueriesSlayer && (GetPermLevel(targetMember) >= ServerPermLevel.TechnicalQueriesSlayer || targetMember.IsBot))
             {
                 await ctx.EditResponseAsync(new DiscordWebhookBuilder().WithContent($"{Program.cfgjson.Emoji.Error} {ctx.User.Mention}, you cannot mute other TQS or staff members."));

--- a/Commands/InteractionCommands/MuteInteractions.cs
+++ b/Commands/InteractionCommands/MuteInteractions.cs
@@ -89,5 +89,47 @@
                     await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} That user doesn't appear to be muted, *and* an error occurred while attempting to unmute them anyway. Please contact the bot owner, the error has been logged.");
                 }
         }
+
+        [SlashCommand("tqsmute", "Temporarily mute a user in tech support channels.")]
+        [SlashRequireHomeserverPerm(ServerPermLevel.TechnicalQueriesSlayer)]
+        public async Task TqsMuteSlashCommand(
+            InteractionContext ctx,
+            [Option("user", "The user to mute.")] DiscordUser targetUser,
+            [Option("reason", "The reason for the mute.")] string reason)
+        {
+            await ctx.DeferAsync(ephemeral: true);
+            
+            // Only allow usage in #tech-support, #tech-support-forum, and their threads
+            if (ctx.Channel.Id != Program.cfgjson.TechSupportChannel &&
+                ctx.Channel.Id != Program.cfgjson.SupportForumId &&
+                ctx.Channel.Parent.Id != Program.cfgjson.TechSupportChannel &&
+                ctx.Channel.Parent.Id != Program.cfgjson.SupportForumId)
+            {
+                await ctx.EditResponseAsync(new DiscordWebhookBuilder().WithContent($"{Program.cfgjson.Emoji.Error} This command can only be used in <#{Program.cfgjson.TechSupportChannel}>, <#{Program.cfgjson.SupportForumId}>, and threads in those channels!"));
+                return;
+            }
+            
+            DiscordMember targetMember = default;
+            try
+            {
+                targetMember = await ctx.Guild.GetMemberAsync(targetUser.Id);
+            }
+            catch (DSharpPlus.Exceptions.NotFoundException)
+            {
+                // blah
+            }
+
+            if (targetMember != default && GetPermLevel(ctx.Member) == ServerPermLevel.TechnicalQueriesSlayer && (GetPermLevel(targetMember) >= ServerPermLevel.TechnicalQueriesSlayer || targetMember.IsBot))
+            {
+                await ctx.EditResponseAsync(new DiscordWebhookBuilder().WithContent($"{Program.cfgjson.Emoji.Error} {ctx.User.Mention}, you cannot mute other TQS or staff members."));
+                return;
+            }
+
+            // mute duration is static for TQS mutes
+            TimeSpan muteDuration = TimeSpan.FromHours(Program.cfgjson.TqsMuteDurationHours);
+
+            await MuteHelpers.MuteUserAsync(targetUser, reason, ctx.User.Id, ctx.Guild, ctx.Channel, muteDuration, true, true);
+            await ctx.EditResponseAsync(new DiscordWebhookBuilder().WithContent("Done. Please open a modmail thread for this user if you haven't already!"));
+        }
     }
 }

--- a/Commands/Mutes.cs
+++ b/Commands/Mutes.cs
@@ -113,6 +113,18 @@ namespace Cliptok.Commands
                 return;
             }
             
+            // Check if the user is already muted; disallow TQS-mute if so
+            
+            DiscordRole mutedRole = ctx.Guild.GetRole(Program.cfgjson.MutedRole);
+            DiscordRole tqsMutedRole = ctx.Guild.GetRole(Program.cfgjson.TqsMutedRole);
+            
+            if ((await Program.db.HashExistsAsync("mutes", targetUser.Id)) || (ctx.Member != default && (ctx.Member.Roles.Contains(mutedRole) || ctx.Member.Roles.Contains(tqsMutedRole))))
+            {
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} {ctx.User.Mention}, that user is already muted.");
+                return;
+            }
+            
+            // Get member
             DiscordMember targetMember = default;
             try
             {
@@ -123,6 +135,7 @@ namespace Cliptok.Commands
                 // blah
             }
 
+            // Check if user to be muted is staff or TQS, and disallow if so
             if (targetMember != default && GetPermLevel(ctx.Member) == ServerPermLevel.TechnicalQueriesSlayer && (GetPermLevel(targetMember) >= ServerPermLevel.TechnicalQueriesSlayer || targetMember.IsBot))
             {
                 await ctx.Channel.SendMessageAsync($"{Program.cfgjson.Emoji.Error} {ctx.User.Mention}, you cannot mute other TQS or staff members.");

--- a/Events/MemberEvents.cs
+++ b/Events/MemberEvents.cs
@@ -127,12 +127,13 @@ namespace Cliptok.Events
                 return;
 
             var muteRole = e.Guild.GetRole(cfgjson.MutedRole);
+            var tqsMuteRole = e.Guild.GetRole(cfgjson.TqsMutedRole);
             var userMute = await db.HashGetAsync("mutes", e.Member.Id);
 
-            if (!userMute.IsNull && !e.Member.Roles.Contains(muteRole))
+            if (!userMute.IsNull && !e.Member.Roles.Contains(muteRole) & !e.Member.Roles.Contains(tqsMuteRole))
                 db.HashDeleteAsync("mutes", e.Member.Id);
 
-            if (e.Member.Roles.Contains(muteRole) && userMute.IsNull)
+            if ((e.Member.Roles.Contains(muteRole) || e.Member.Roles.Contains(tqsMuteRole)) && userMute.IsNull)
             {
                 MemberPunishment newMute = new()
                 {
@@ -146,7 +147,7 @@ namespace Cliptok.Events
                 db.HashSetAsync("mutes", e.Member.Id, JsonConvert.SerializeObject(newMute));
             }
 
-            if (!userMute.IsNull && !e.Member.Roles.Contains(muteRole))
+            if (!userMute.IsNull && !e.Member.Roles.Contains(muteRole) && !e.Member.Roles.Contains(tqsMuteRole))
                 db.HashDeleteAsync("mutes", e.Member.Id);
 
             string rolesStr = "None";

--- a/Helpers/MuteHelpers.cs
+++ b/Helpers/MuteHelpers.cs
@@ -101,11 +101,13 @@
         }
 
         // Only to be used on naughty users.
-        public static async Task<(DiscordMessage? dmMessage, DiscordMessage? chatMessage)> MuteUserAsync(DiscordUser naughtyUser, string reason, ulong moderatorId, DiscordGuild guild, DiscordChannel channel = null, TimeSpan muteDuration = default, bool alwaysRespond = false)
+        public static async Task<(DiscordMessage? dmMessage, DiscordMessage? chatMessage)> MuteUserAsync(DiscordUser naughtyUser, string reason, ulong moderatorId, DiscordGuild guild, DiscordChannel channel = null, TimeSpan muteDuration = default, bool alwaysRespond = false, bool isTqsMute = false)
         {
             bool permaMute = false;
             DateTime? actionTime = DateTime.Now;
-            DiscordRole mutedRole = guild.GetRole(Program.cfgjson.MutedRole);
+            DiscordRole mutedRole = isTqsMute
+                ? guild.GetRole(Program.cfgjson.TqsMutedRole)
+                : guild.GetRole(Program.cfgjson.MutedRole);
             DateTime? expireTime = actionTime + muteDuration;
             DiscordMember moderator = await guild.GetMemberAsync(moderatorId);
 
@@ -131,27 +133,31 @@
             {
                 try
                 {
-                    string fullReason = $"[Mute by {DiscordHelpers.UniqueUsername(moderator)}]: {reason}";
+                    string fullReason = $"[{(isTqsMute ? "TQS " : "")}Mute by {DiscordHelpers.UniqueUsername(moderator)}]: {reason}";
                     await naughtyMember.GrantRoleAsync(mutedRole, fullReason);
-                    try
+                    
+                    // for global mutes, issue timeout & kick from any voice channel; does not apply to TQS mutes as they are not server-wide
+                    if (!isTqsMute)
                     {
                         try
                         {
-                            await naughtyMember.TimeoutAsync(expireTime + TimeSpan.FromSeconds(10), fullReason);
+                            try
+                            {
+                                await naughtyMember.TimeoutAsync(expireTime + TimeSpan.FromSeconds(10), fullReason);
+                            }
+                            catch (Exception e)
+                            {
+                                Program.discord.Logger.LogError(e, "Failed to issue timeout to {user}", naughtyMember.Id);
+                            }
+
+                            // Remove the member from any Voice Channel they're currently in.
+                            await naughtyMember.ModifyAsync(x => x.VoiceChannel = null);
                         }
-                        catch (Exception e)
+                        catch (DSharpPlus.Exceptions.UnauthorizedException)
                         {
-                            Program.discord.Logger.LogError(e, "Failed to issue timeout to {user}", naughtyMember.Id);
+                            // do literally nothing. who cares?
                         }
-
-                        // Remove the member from any Voice Channel they're currently in.
-                        await naughtyMember.ModifyAsync(x => x.VoiceChannel = null);
                     }
-                    catch (DSharpPlus.Exceptions.UnauthorizedException)
-                    {
-                        // do literally nothing. who cares?
-                    }
-
                 }
                 catch
                 {
@@ -170,12 +176,32 @@
                 }
                 else
                 {
-                    await LogChannelHelper.LogMessageAsync("mod", new DiscordMessageBuilder()
-                        .WithContent($"{Program.cfgjson.Emoji.Muted} {naughtyUser.Mention} was successfully muted for **{TimeHelpers.TimeToPrettyFormat(muteDuration, false)}** by {moderator.Mention}." +
-                            $"\nReason: **{reason}**" +
-                            $"\nMute expires: <t:{TimeHelpers.ToUnixTimestamp(expireTime)}:R>")
-                        .WithAllowedMentions(Mentions.None)
-                    );
+                    // if TQS mute, log to investigations channel also & make it clear in regular mod logs that it's a TQS mute
+                    if (isTqsMute)
+                    {
+                        await LogChannelHelper.LogMessageAsync("investigations", new DiscordMessageBuilder()
+                            .WithContent($"{Program.cfgjson.Emoji.Muted} {naughtyUser.Mention} was TQS-muted for **{TimeHelpers.TimeToPrettyFormat(muteDuration, false)}** by {moderator.Mention}." +
+                                $"\nReason: **{reason}**" +
+                                $"\nMute expires: <t:{TimeHelpers.ToUnixTimestamp(expireTime)}:R>")
+                            .WithAllowedMentions(Mentions.None)
+                        );
+                        
+                        await LogChannelHelper.LogMessageAsync("mod", new DiscordMessageBuilder()
+                            .WithContent($"{Program.cfgjson.Emoji.Muted} {naughtyUser.Mention} was TQS-muted for **{TimeHelpers.TimeToPrettyFormat(muteDuration, false)}** by {moderator.Mention}." +
+                                         $"\nReason: **{reason}**" +
+                                         $"\nMute expires: <t:{TimeHelpers.ToUnixTimestamp(expireTime)}:R>")
+                            .WithAllowedMentions(Mentions.None)
+                        );
+                    }
+                    else
+                    {
+                        await LogChannelHelper.LogMessageAsync("mod", new DiscordMessageBuilder()
+                            .WithContent($"{Program.cfgjson.Emoji.Muted} {naughtyUser.Mention} was successfully muted for **{TimeHelpers.TimeToPrettyFormat(muteDuration, false)}** by {moderator.Mention}." +
+                                         $"\nReason: **{reason}**" +
+                                         $"\nMute expires: <t:{TimeHelpers.ToUnixTimestamp(expireTime)}:R>")
+                            .WithAllowedMentions(Mentions.None)
+                        );
+                    }
                 }
             }
             catch (Exception ex)
@@ -195,9 +221,18 @@
 
                     else
                     {
-                        output.dmMessage = await naughtyMember.SendMessageAsync($"{Program.cfgjson.Emoji.Muted} You have been muted in **{guild.Name}** for **{TimeHelpers.TimeToPrettyFormat(muteDuration, false)}**!" +
-                            $"\nReason: **{reason}**" +
-                            $"\nMute expires: <t:{TimeHelpers.ToUnixTimestamp(expireTime)}:R>");
+                        if (isTqsMute)
+                        {
+                            output.dmMessage = await naughtyMember.SendMessageAsync($"{Program.cfgjson.Emoji.Muted} You have been temporarily muted in **tech support channels only** in **{guild.Name}** for **{TimeHelpers.TimeToPrettyFormat(muteDuration, false)}** pending action from a Moderator." +
+                                $"\nReason: **{reason}**" +
+                                $"\nMute expires: <t:{TimeHelpers.ToUnixTimestamp(expireTime)}:R>");
+                        }
+                        else
+                        {
+                            output.dmMessage = await naughtyMember.SendMessageAsync($"{Program.cfgjson.Emoji.Muted} You have been muted in **{guild.Name}** for **{TimeHelpers.TimeToPrettyFormat(muteDuration, false)}**!" +
+                                $"\nReason: **{reason}**" +
+                                $"\nMute expires: <t:{TimeHelpers.ToUnixTimestamp(expireTime)}:R>");
+                        }
                     }
                 }
                 catch (DSharpPlus.Exceptions.UnauthorizedException)
@@ -208,7 +243,16 @@
                         if (muteDuration == default)
                             output.chatMessage = await channel.SendMessageAsync($"{Program.cfgjson.Emoji.Muted} {naughtyUser.Mention} has been muted: **{reason}**");
                         else
-                            output.chatMessage = await channel.SendMessageAsync($"{Program.cfgjson.Emoji.Muted} {naughtyUser.Mention} has been muted for **{TimeHelpers.TimeToPrettyFormat(muteDuration, false)}**: **{reason}**");
+                        {
+                            if (isTqsMute)
+                            {
+                                output.chatMessage = await channel.SendMessageAsync($"{Program.cfgjson.Emoji.Muted} {naughtyUser.Mention} has been temporarily muted, in tech support channels only, for **{TimeHelpers.TimeToPrettyFormat(muteDuration, false)}** pending action from a Moderator: **{reason}**");
+                            }
+                            else
+                            {
+                                output.chatMessage = await channel.SendMessageAsync($"{Program.cfgjson.Emoji.Muted} {naughtyUser.Mention} has been muted for **{TimeHelpers.TimeToPrettyFormat(muteDuration, false)}**: **{reason}**");
+                            }
+                        }
                     }
                 }
             }
@@ -219,7 +263,16 @@
                 if (muteDuration == default)
                     output.chatMessage = await channel.SendMessageAsync($"{Program.cfgjson.Emoji.Muted} {naughtyUser.Mention} has been muted: **{reason}**");
                 else
-                    output.chatMessage = await channel.SendMessageAsync($"{Program.cfgjson.Emoji.Muted} {naughtyUser.Mention} has been muted for **{TimeHelpers.TimeToPrettyFormat(muteDuration, false)}**: **{reason}**");
+                {
+                    if (isTqsMute)
+                    {
+                        output.chatMessage = await channel.SendMessageAsync($"{Program.cfgjson.Emoji.Muted} {naughtyUser.Mention} has been temporarily muted, in tech support channels only, for **{TimeHelpers.TimeToPrettyFormat(muteDuration, false)}** pending action from a Moderator: **{reason}**");
+                    }
+                    else
+                    {
+                        output.chatMessage = await channel.SendMessageAsync($"{Program.cfgjson.Emoji.Muted} {naughtyUser.Mention} has been muted for **{TimeHelpers.TimeToPrettyFormat(muteDuration, false)}**: **{reason}**");
+                    }
+                }
             }
 
             MemberPunishment newMute = new()
@@ -255,10 +308,12 @@
         {
             var muteDetailsJson = await Program.db.HashGetAsync("mutes", targetUser.Id);
             bool success = false;
+            bool wasTqsMute = false;
             DiscordGuild guild = await Program.discord.GetGuildAsync(Program.cfgjson.ServerID);
 
             // todo: store per-guild
             DiscordRole mutedRole = guild.GetRole(Program.cfgjson.MutedRole);
+            DiscordRole tqsMutedRole = guild.GetRole(Program.cfgjson.TqsMutedRole);
             DiscordMember member = default;
             try
             {
@@ -282,7 +337,20 @@
                 // Perhaps we could be catching something specific, but this should do for now.
                 try
                 {
-                    await member.RevokeRoleAsync(role: mutedRole, reason);
+                    // Try to revoke standard Muted role first. If it fails, the user might just be TQS-muted.
+                    // Try removing TQS mute role regardless of whether we could successfully remove the standard
+                    // muted role.
+                    // If both attempts fail, do standard failure error handling.
+                    try
+                    {
+                        await member.RevokeRoleAsync(role: mutedRole, reason);
+                    }
+                    finally
+                    {
+                        await member.RevokeRoleAsync(role: tqsMutedRole, reason);
+                        wasTqsMute = true; // only true if TQS mute role was found & removed
+                    }
+                    
                     foreach (var role in member.Roles)
                     {
                         if (role.Name == "Muted" && role.Id != Program.cfgjson.MutedRole)
@@ -310,7 +378,11 @@
                 }
                 try
                 {
-                    await member.TimeoutAsync(until: null, reason: reason);
+                    // only try to remove timeout for non-TQS mutes
+                    // TQS mutes are not server-wide so this would fail every time for TQS mutes,
+                    // and we don't want to log a failure for every removed TQS mute
+                    if (!wasTqsMute)
+                        await member.TimeoutAsync(until: null, reason: reason);
                 }
                 catch (Exception ex)
                 {

--- a/Helpers/MuteHelpers.cs
+++ b/Helpers/MuteHelpers.cs
@@ -223,7 +223,7 @@
                     {
                         if (isTqsMute)
                         {
-                            output.dmMessage = await naughtyMember.SendMessageAsync($"{Program.cfgjson.Emoji.Muted} You have been temporarily muted in **tech support channels only** in **{guild.Name}** for **{TimeHelpers.TimeToPrettyFormat(muteDuration, false)}** pending action from a Moderator." +
+                            output.dmMessage = await naughtyMember.SendMessageAsync($"{Program.cfgjson.Emoji.Muted} You have been temporarily muted, in **tech support channels only**, in **{guild.Name}** for **{TimeHelpers.TimeToPrettyFormat(muteDuration, false)}** pending action from a Moderator." +
                                 $"\nReason: **{reason}**" +
                                 $"\nMute expires: <t:{TimeHelpers.ToUnixTimestamp(expireTime)}:R>");
                         }

--- a/Structs.cs
+++ b/Structs.cs
@@ -286,6 +286,12 @@
 
         [JsonProperty("insiderCanaryThread")]
         public ulong InsiderCanaryThread { get; set; } = 0;
+        
+        [JsonProperty("tqsMutedRole")]
+        public ulong TqsMutedRole { get; private set; }
+        
+        [JsonProperty("tqsMuteDurationHours")]
+        public int TqsMuteDurationHours { get; private set; }
 
     }
 

--- a/config.json
+++ b/config.json
@@ -317,6 +317,6 @@
   "dmAutoresponseTimeLimit": 6,
   "autoDeleteEmptyThreads": true,
   "insiderCanaryThread": 1082394217168523315,
-  "tqsMutedRole": 1206705643369795664,
+  "tqsMutedRole": 752821045408563230,
   "tqsMuteDurationHours": 2
 }

--- a/config.json
+++ b/config.json
@@ -316,5 +316,7 @@
   "insiderCommandLockedToChannel": 187649467611086849,
   "dmAutoresponseTimeLimit": 6,
   "autoDeleteEmptyThreads": true,
-  "insiderCanaryThread": 1082394217168523315
+  "insiderCanaryThread": 1082394217168523315,
+  "tqsMutedRole": 1206705643369795664,
+  "tqsMuteDurationHours": 2
 }


### PR DESCRIPTION
This PR closes #168.

Adds two new commands, `!tqsmute` and `/tqsmute`, that Technical Queries Slayer members can use to temp-mute other members.

TQS members can provide a reason for the mute, but cannot change the duration, nor can they mute other TQS members or staff. Mute duration can be configured with `tqsMuteDurationHours` in config.json.

The `tqsmute` commands can only be used in tech support channels and their threads.
<img width="867" alt="image" src="https://github.com/Erisa/Cliptok/assets/51096169/25e3661a-c7ca-453e-8e09-c4219b80d6e7">

When TQS members use the slash command to mute a member, it is suggested that they create a modmail thread to provide moderators with context & prompt further mod action. Unfortunately this is not done when `!tqsmute` is used, as I wasn't sure what the best way to get this message across privately would be—ephemeral messages only work with slash commands, and I don't really like the idea of a DM.
<img width="1022" alt="image" src="https://github.com/Erisa/Cliptok/assets/51096169/89f9276a-29e2-469f-9098-6db760e54bbf">

TQS mutes are logged in the standard mod log channel, and are also sent to the investigations channel.
<img width="617" alt="image" src="https://github.com/Erisa/Cliptok/assets/51096169/7c36ef54-2f9d-48eb-b5a4-afca107fafbb">

TQS mutes are stored in the db the same way regular mutes are. There is no special flag in the db to identify that they are TQS mutes, but there is a note on the log in log channels (see above). If a moderator uses the `mute` command to apply a standard mute to a TQS-muted member, the mute in the db is overwritten. 

This PR also updates the `unmute` command to remove both the standard Muted role and the TQS Muted role. There is not a separate command for removing TQS mutes only.