### PR TITLE
Automatically delete automatic warning messages

### DIFF
--- a/Commands/Debug.cs
+++ b/Commands/Debug.cs
@@ -161,11 +161,12 @@
                 var msg = await ctx.RespondAsync("Checking for pending scheduled tasks...");
                 bool bans = await Tasks.PunishmentTasks.CheckBansAsync();
                 bool mutes = await Tasks.PunishmentTasks.CheckMutesAsync();
+                bool warns = await Tasks.PunishmentTasks.CheckAutomaticWarningsAsync();
                 bool reminders = await Tasks.ReminderTasks.CheckRemindersAsync();
                 bool raidmode = await Tasks.RaidmodeTasks.CheckRaidmodeAsync(ctx.Guild.Id);
                 bool unlocks = await Tasks.LockdownTasks.CheckUnlocksAsync();
 
-                await msg.ModifyAsync($"Unban check result: `{bans}`\nUnmute check result: `{mutes}`\nReminders check result: `{reminders}`\nRaidmode check result: `{raidmode}`\nUnlocks check result: `{unlocks}`");
+                await msg.ModifyAsync($"Unban check result: `{bans}`\nUnmute check result: `{mutes}`\nAutomatic warning message check result: `{warns}`\nReminders check result: `{reminders}`\nRaidmode check result: `{raidmode}`\nUnlocks check result: `{unlocks}`");
             }
 
             [Command("sh")]

--- a/Helpers/WarningHelpers.cs
+++ b/Helpers/WarningHelpers.cs
@@ -220,6 +220,10 @@
                 };
 
             Program.db.HashSet(targetUser.Id.ToString(), warning.WarningId, JsonConvert.SerializeObject(warning));
+            
+            // If warning is automatic (if responsible moderator is a bot), add to list so the context message can be more-easily deleted later
+            if (modUser.IsBot)
+                Program.db.HashSet("automaticWarnings", warningId, JsonConvert.SerializeObject(warning));
 
             LogChannelHelper.LogMessageAsync("mod",
                 new DiscordMessageBuilder()

--- a/Program.cs
+++ b/Program.cs
@@ -185,6 +185,7 @@ namespace Cliptok
                     [
                         Tasks.PunishmentTasks.CheckMutesAsync(),
                         Tasks.PunishmentTasks.CheckBansAsync(),
+                        Tasks.PunishmentTasks.CheckAutomaticWarningsAsync(),
                         Tasks.ReminderTasks.CheckRemindersAsync(),
                         Tasks.RaidmodeTasks.CheckRaidmodeAsync(cfgjson.ServerID),
                         Tasks.LockdownTasks.CheckUnlocksAsync(),

--- a/Structs.cs
+++ b/Structs.cs
@@ -292,6 +292,9 @@
         
         [JsonProperty("tqsMuteDurationHours")]
         public int TqsMuteDurationHours { get; private set; }
+        
+        [JsonProperty("autoWarnMsgAutoDeleteDays")]
+        public int AutoWarnMsgAutoDeleteDays { get; private set; }
 
     }
 

--- a/Tasks/PunishmentTasks.cs
+++ b/Tasks/PunishmentTasks.cs
@@ -66,10 +66,12 @@
         {
             if (Program.cfgjson.AutoWarnMsgAutoDeleteDays == 0)
                 return false;
+
             Dictionary<string, UserWarning> warnList = Program.db.HashGetAll("automaticWarnings").ToDictionary(
                 x => x.Name.ToString(),
                 x => JsonConvert.DeserializeObject<UserWarning>(x.Value)
             );
+
             if (warnList is null | warnList.Keys.Count == 0)
                 return false;
             else
@@ -87,9 +89,7 @@
                         success = true;
                     }
                 }
-#if DEBUG
                 Program.discord.Logger.LogDebug(Program.CliptokEventID, "Checked automatic warnings at {time} with result: {result}", DateTime.Now, success);
-#endif
                 return success;
             }
         }

--- a/Tasks/PunishmentTasks.cs
+++ b/Tasks/PunishmentTasks.cs
@@ -64,6 +64,8 @@
 
         public static async Task<bool> CheckAutomaticWarningsAsync()
         {
+            if (Program.cfgjson.AutoWarnMsgAutoDeleteDays == 0)
+                return false;
             Dictionary<string, UserWarning> warnList = Program.db.HashGetAll("automaticWarnings").ToDictionary(
                 x => x.Name.ToString(),
                 x => JsonConvert.DeserializeObject<UserWarning>(x.Value)

--- a/Tasks/PunishmentTasks.cs
+++ b/Tasks/PunishmentTasks.cs
@@ -61,6 +61,36 @@
                 return success;
             }
         }
+
+        public static async Task<bool> CheckAutomaticWarningsAsync()
+        {
+            Dictionary<string, UserWarning> warnList = Program.db.HashGetAll("automaticWarnings").ToDictionary(
+                x => x.Name.ToString(),
+                x => JsonConvert.DeserializeObject<UserWarning>(x.Value)
+            );
+            if (warnList is null | warnList.Keys.Count == 0)
+                return false;
+            else
+            {
+                // The success value will be changed later if any of the message deletes are successful.
+                bool success = false;
+                foreach (KeyValuePair<string, UserWarning> entry in warnList)
+                {
+                    UserWarning warn = entry.Value;
+                    if (DateTime.Now > warn.WarnTimestamp.AddDays(Program.cfgjson.AutoWarnMsgAutoDeleteDays))
+                    {
+                        var contextMessage = await DiscordHelpers.GetMessageFromReferenceAsync(warn.ContextMessageReference);
+                        await contextMessage.DeleteAsync();
+                        Program.db.HashDelete("automaticWarnings", warn.WarningId);
+                        success = true;
+                    }
+                }
+#if DEBUG
+                Program.discord.Logger.LogDebug(Program.CliptokEventID, "Checked automatic warnings at {time} with result: {result}", DateTime.Now, success);
+#endif
+                return success;
+            }
+        }
     }
 
 }

--- a/config.json
+++ b/config.json
@@ -320,5 +320,6 @@
   "autoDeleteEmptyThreads": true,
   "insiderCanaryThread": 1082394217168523315,
   "tqsMutedRole": 752821045408563230,
-  "tqsMuteDurationHours": 2
+  "tqsMuteDurationHours": 2,
+  "autoWarnMsgAutoDeleteDays": 3
 }


### PR DESCRIPTION
This PR closes #192.

Adds the ability to have Cliptok automatically delete the public chat messages for automatic warnings after a set number of days (`autoWarnMsgAutoDeleteDays` in config.json). Currently set to 3 and can be set to 0 to disable.

Only the public chat message for the warning is deleted—private logs, and the warning itself, aren't touched.

With this change, in addition to how they are typically stored, automatic warnings are stored in the db under a new `automaticWarnings` hash so that the entire list of warnings doesn't have to be enumerated during each check.