### PR TITLE
Add the ability to pause & unpause DMs

### DIFF
--- a/Commands/InteractionCommands/SecurityActionInteractions.cs
+++ b/Commands/InteractionCommands/SecurityActionInteractions.cs
@@ -42,10 +42,12 @@ namespace Cliptok.Commands.InteractionCommands
 
             // respond
             if (setActionsResponse.IsSuccessStatusCode)
-                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Successfully paused DMs for **{TimeHelpers.TimeToPrettyFormat(t.Subtract(ctx.Interaction.CreationTimestamp.DateTime.ToLocalTime()), false)}**!");
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Successfully paused DMs until <t:{TimeHelpers.ToUnixTimestamp(t)}>!");
             else
-                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} Something went wrong and I wasn't able to pause DMs! Discord returned status code `{setActionsResponse.StatusCode}`.");
-        }
+            {
+                ctx.Client.Logger.LogError("Failed to set Security Actions.\nPayload: {payload}\nResponse: {statuscode} {body}", newSecurityActions.ToString(), (int)setActionsResponse.StatusCode, await setActionsResponse.Content.ReadAsStringAsync());
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} Something went wrong and I wasn't able to unpause DMs! Discord returned status code `{setActionsResponse.StatusCode}`.");
+            }
 
         [SlashCommand("unpausedms", "Unpause DMs between server members.", defaultPermission: false)]
         [HomeServer, SlashRequireHomeserverPerm(ServerPermLevel.Moderator), SlashCommandPermissions(Permissions.ModerateMembers)]
@@ -88,7 +90,9 @@ namespace Cliptok.Commands.InteractionCommands
             if (setActionsResponse.IsSuccessStatusCode)
                 await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Successfully unpaused DMs!");
             else
-                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} Something went wrong and I wasn't able to unpause DMs! Discord returned status code `{setActionsResponse.StatusCode}`.");
-        }
+            {
+                ctx.Client.Logger.LogError("Failed to set Security Actions.\nPayload: {payload}\nResponse: {statuscode} {body}", newSecurityActions.ToString(), (int)setActionsResponse.StatusCode, await setActionsResponse.Content.ReadAsStringAsync());
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} Something went wrong and I wasn't able to pause DMs! Discord returned status code `{setActionsResponse.StatusCode}`.");
+            }
     }
 }

--- a/Commands/InteractionCommands/SecurityActionInteractions.cs
+++ b/Commands/InteractionCommands/SecurityActionInteractions.cs
@@ -48,6 +48,7 @@ namespace Cliptok.Commands.InteractionCommands
                 ctx.Client.Logger.LogError("Failed to set Security Actions.\nPayload: {payload}\nResponse: {statuscode} {body}", newSecurityActions.ToString(), (int)setActionsResponse.StatusCode, await setActionsResponse.Content.ReadAsStringAsync());
                 await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} Something went wrong and I wasn't able to unpause DMs! Discord returned status code `{setActionsResponse.StatusCode}`.");
             }
+        }
 
         [SlashCommand("unpausedms", "Unpause DMs between server members.", defaultPermission: false)]
         [HomeServer, SlashRequireHomeserverPerm(ServerPermLevel.Moderator), SlashCommandPermissions(Permissions.ModerateMembers)]
@@ -94,5 +95,6 @@ namespace Cliptok.Commands.InteractionCommands
                 ctx.Client.Logger.LogError("Failed to set Security Actions.\nPayload: {payload}\nResponse: {statuscode} {body}", newSecurityActions.ToString(), (int)setActionsResponse.StatusCode, await setActionsResponse.Content.ReadAsStringAsync());
                 await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} Something went wrong and I wasn't able to pause DMs! Discord returned status code `{setActionsResponse.StatusCode}`.");
             }
+        }
     }
 }

--- a/Commands/InteractionCommands/SecurityActionInteractions.cs
+++ b/Commands/InteractionCommands/SecurityActionInteractions.cs
@@ -1,0 +1,94 @@
+namespace Cliptok.Commands.InteractionCommands
+{
+    public class SecurityActionInteractions : ApplicationCommandModule
+    {
+        [SlashCommand("pausedms", "Temporarily pause DMs between server members.", defaultPermission: false)]
+        [HomeServer, SlashRequireHomeserverPerm(ServerPermLevel.Moderator), SlashCommandPermissions(Permissions.ModerateMembers)]
+        public async Task SlashPauseDMs(InteractionContext ctx, [Option("time", "The amount of time to pause DMs for. Cannot be greater than 24 hours.")] string time)
+        {
+            // need to make our own api calls because D#+ can't do this natively?
+
+            // parse time from message
+            DateTime t = HumanDateParser.HumanDateParser.Parse(time);
+            if (t <= DateTime.Now)
+            {
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} Time can't be in the past!");
+                return;
+            }
+            if (t > DateTime.Now.AddHours(24))
+            {
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} Time can't be greater than 24 hours!");
+                return;
+            }
+            var dmsDisabledUntil = t.ToUniversalTime().ToString("o");
+            
+            // get current security actions to avoid unintentionally resetting invites_disabled_until
+            var currentActions = await SecurityActionHelpers.GetCurrentSecurityActions(ctx.Guild.Id);
+            JToken invitesDisabledUntil;
+            if (currentActions is null || !currentActions.HasValues)
+                invitesDisabledUntil = null;
+            else
+                invitesDisabledUntil = currentActions["invites_disabled_until"];
+            
+            // create json body
+            var newSecurityActions = JsonConvert.SerializeObject(new
+            {
+                invites_disabled_until = invitesDisabledUntil,
+                dms_disabled_until = dmsDisabledUntil,
+            });
+
+            // set actions
+            var setActionsResponse = await SecurityActionHelpers.SetCurrentSecurityActions(ctx.Guild.Id, newSecurityActions);
+
+            // respond
+            if (setActionsResponse.IsSuccessStatusCode)
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Successfully paused DMs for **{TimeHelpers.TimeToPrettyFormat(t.Subtract(ctx.Interaction.CreationTimestamp.DateTime.ToLocalTime()), false)}**!");
+            else
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} Something went wrong and I wasn't able to pause DMs! Discord returned status code `{setActionsResponse.StatusCode}`.");
+        }
+
+        [SlashCommand("unpausedms", "Unpause DMs between server members.", defaultPermission: false)]
+        [HomeServer, SlashRequireHomeserverPerm(ServerPermLevel.Moderator), SlashCommandPermissions(Permissions.ModerateMembers)]
+        public async Task SlashUnpauseDMs(InteractionContext ctx)
+        {
+            // need to make our own api calls because D#+ can't do this natively?
+            
+            // get current security actions to avoid unintentionally resetting invites_disabled_until
+            var currentActions = await SecurityActionHelpers.GetCurrentSecurityActions(ctx.Guild.Id);
+            JToken dmsDisabledUntil, invitesDisabledUntil;
+            if (currentActions is null || !currentActions.HasValues)
+            {
+                dmsDisabledUntil = null;
+                invitesDisabledUntil = null;
+            }
+            else
+            {
+                dmsDisabledUntil = currentActions["dms_disabled_until"];
+                invitesDisabledUntil = currentActions["invites_disabled_until"];
+            }
+
+            // if dms are already unpaused, return error
+            if (dmsDisabledUntil is null)
+            {
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} DMs are already unpaused!");
+                return;
+            }
+            
+            // create json body
+            var newSecurityActions = JsonConvert.SerializeObject(new
+            {
+                invites_disabled_until = invitesDisabledUntil,
+                dms_disabled_until = (object)null,
+            });
+            
+            // set actions
+            var setActionsResponse = await SecurityActionHelpers.SetCurrentSecurityActions(ctx.Guild.Id, newSecurityActions);
+
+            // respond
+            if (setActionsResponse.IsSuccessStatusCode)
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Successfully unpaused DMs!");
+            else
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} Something went wrong and I wasn't able to unpause DMs! Discord returned status code `{setActionsResponse.StatusCode}`.");
+        }
+    }
+}

--- a/Commands/SecurityActions.cs
+++ b/Commands/SecurityActions.cs
@@ -1,0 +1,111 @@
+namespace Cliptok.Commands
+{
+    public class SecurityActions : BaseCommandModule
+    {
+        [Command("pausedms")]
+        [Description("Temporarily pause DMs between server members.")]
+        [HomeServer, RequireHomeserverPerm(ServerPermLevel.Moderator)]
+        public async Task PauseDMs(CommandContext ctx, [Description("The amount of time to pause DMs for."), RemainingText] string time)
+        {
+            if (string.IsNullOrWhiteSpace(time))
+            {
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} You must provide an amount of time to pause DMs for!");
+                return;
+            }
+            
+            // need to make our own api calls because D#+ can't do this natively?
+
+            // parse time from message
+            DateTime t;
+            try
+            {
+                t = HumanDateParser.HumanDateParser.Parse(time);
+            }
+            catch (HumanDateParser.ParseException)
+            {
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} I didn't understand that time! Please try again.");
+                return;
+            }
+            if (t <= DateTime.Now)
+            {
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} Time can't be in the past!");
+                return;
+            }
+            if (t > DateTime.Now.AddHours(24))
+            {
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} Time can't be greater than 24 hours!");
+                return;
+            }
+            var dmsDisabledUntil = t.ToUniversalTime().ToString("o");
+            
+            // get current security actions to avoid unintentionally resetting invites_disabled_until
+            var currentActions = await SecurityActionHelpers.GetCurrentSecurityActions(ctx.Guild.Id);
+            JToken invitesDisabledUntil;
+            if (currentActions is null || !currentActions.HasValues)
+                invitesDisabledUntil = null;
+            else
+                invitesDisabledUntil = currentActions["invites_disabled_until"];
+            
+            // create json body
+            var newSecurityActions = JsonConvert.SerializeObject(new
+            {
+                invites_disabled_until = invitesDisabledUntil,
+                dms_disabled_until = dmsDisabledUntil,
+            });
+
+            // set actions
+            var setActionsResponse = await SecurityActionHelpers.SetCurrentSecurityActions(ctx.Guild.Id, newSecurityActions);
+
+            // respond
+            if (setActionsResponse.IsSuccessStatusCode)
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Successfully paused DMs for **{TimeHelpers.TimeToPrettyFormat(t.Subtract(ctx.Message.Timestamp.DateTime), false)}**!");
+            else
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} Something went wrong and I wasn't able to pause DMs! Discord returned status code `{setActionsResponse.StatusCode}`.");
+        }
+
+        [Command("unpausedms")]
+        [Description("Unpause DMs between server members.")]
+        [HomeServer, RequireHomeserverPerm(ServerPermLevel.Moderator)]
+        public async Task UnpauseDMs(CommandContext ctx)
+        {
+            // need to make our own api calls because D#+ can't do this natively?
+            
+            // get current security actions to avoid unintentionally resetting invites_disabled_until
+            var currentActions = await SecurityActionHelpers.GetCurrentSecurityActions(ctx.Guild.Id);
+            JToken dmsDisabledUntil, invitesDisabledUntil;
+            if (currentActions is null || !currentActions.HasValues)
+            {
+                dmsDisabledUntil = null;
+                invitesDisabledUntil = null;
+            }
+            else
+            {
+                dmsDisabledUntil = currentActions["dms_disabled_until"];
+                invitesDisabledUntil = currentActions["invites_disabled_until"];
+            }
+
+            // if dms are already unpaused, return error
+            if (dmsDisabledUntil is null)
+            {
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} DMs are already unpaused!");
+                return;
+            }
+            
+            // create json body
+            var newSecurityActions = JsonConvert.SerializeObject(new
+            {
+                invites_disabled_until = invitesDisabledUntil,
+                dms_disabled_until = (object)null,
+            });
+            
+            // set actions
+            var setActionsResponse = await SecurityActionHelpers.SetCurrentSecurityActions(ctx.Guild.Id, newSecurityActions);
+
+            // respond
+            if (setActionsResponse.IsSuccessStatusCode)
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Successfully unpaused DMs!");
+            else
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} Something went wrong and I wasn't able to unpause DMs! Discord returned status code `{setActionsResponse.StatusCode}`.");
+        }
+    }
+}

--- a/Commands/SecurityActions.cs
+++ b/Commands/SecurityActions.cs
@@ -60,8 +60,10 @@ namespace Cliptok.Commands
             if (setActionsResponse.IsSuccessStatusCode)
                 await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Successfully paused DMs for **{TimeHelpers.TimeToPrettyFormat(t.Subtract(ctx.Message.Timestamp.DateTime), false)}**!");
             else
+            {
+                ctx.Client.Logger.LogError("Failed to set Security Actions.\nPayload: {payload}\nResponse: {statuscode} {body}", newSecurityActions.ToString(), (int)setActionsResponse.StatusCode, await setActionsResponse.Content.ReadAsStringAsync());
                 await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} Something went wrong and I wasn't able to pause DMs! Discord returned status code `{setActionsResponse.StatusCode}`.");
-        }
+            }
 
         [Command("unpausedms")]
         [Description("Unpause DMs between server members.")]
@@ -105,7 +107,9 @@ namespace Cliptok.Commands
             if (setActionsResponse.IsSuccessStatusCode)
                 await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Successfully unpaused DMs!");
             else
+            {
+                ctx.Client.Logger.LogError("Failed to set Security Actions.\nPayload: {payload}\nResponse: {statuscode} {body}", newSecurityActions.ToString(), (int)setActionsResponse.StatusCode, await setActionsResponse.Content.ReadAsStringAsync());
                 await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} Something went wrong and I wasn't able to unpause DMs! Discord returned status code `{setActionsResponse.StatusCode}`.");
-        }
+            }
     }
 }

--- a/Commands/SecurityActions.cs
+++ b/Commands/SecurityActions.cs
@@ -64,6 +64,7 @@ namespace Cliptok.Commands
                 ctx.Client.Logger.LogError("Failed to set Security Actions.\nPayload: {payload}\nResponse: {statuscode} {body}", newSecurityActions.ToString(), (int)setActionsResponse.StatusCode, await setActionsResponse.Content.ReadAsStringAsync());
                 await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} Something went wrong and I wasn't able to pause DMs! Discord returned status code `{setActionsResponse.StatusCode}`.");
             }
+        }
 
         [Command("unpausedms")]
         [Description("Unpause DMs between server members.")]
@@ -111,5 +112,6 @@ namespace Cliptok.Commands
                 ctx.Client.Logger.LogError("Failed to set Security Actions.\nPayload: {payload}\nResponse: {statuscode} {body}", newSecurityActions.ToString(), (int)setActionsResponse.StatusCode, await setActionsResponse.Content.ReadAsStringAsync());
                 await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} Something went wrong and I wasn't able to unpause DMs! Discord returned status code `{setActionsResponse.StatusCode}`.");
             }
+        }
     }
 }

--- a/GlobalUsings.cs
+++ b/GlobalUsings.cs
@@ -10,6 +10,7 @@ global using DSharpPlus.EventArgs;
 global using DSharpPlus.SlashCommands;
 global using Microsoft.Extensions.Logging;
 global using Newtonsoft.Json;
+global using Newtonsoft.Json.Linq;
 global using Serilog;
 global using Serilog.Sinks.SystemConsole.Themes;
 global using StackExchange.Redis;

--- a/Helpers/SecurityActionHelpers.cs
+++ b/Helpers/SecurityActionHelpers.cs
@@ -4,7 +4,7 @@ namespace Cliptok.Helpers
     {
         public static async Task<JToken> GetCurrentSecurityActions(ulong guildId)
         {
-            using HttpRequestMessage getActionsRequest = new(HttpMethod.Get, $"https://discord.com/api/v9/guilds/{guildId}");
+            using HttpRequestMessage getActionsRequest = new(HttpMethod.Get, $"https://discord.com/api/v{Program.discord.GatewayVersion}/guilds/{guildId}");
             getActionsRequest.Headers.Authorization = new AuthenticationHeaderValue("Bot", Environment.GetEnvironmentVariable("CLIPTOK_TOKEN") ?? Program.cfgjson.Core.Token);
             
             var getActionsResponse = await Program.httpClient.SendAsync(getActionsRequest);
@@ -15,7 +15,7 @@ namespace Cliptok.Helpers
         {
             // create & send request
             
-            using HttpRequestMessage setActionsRequest = new(HttpMethod.Put, $"https://discord.com/api/v9/guilds/{guildId}/incident-actions");
+            using HttpRequestMessage setActionsRequest = new(HttpMethod.Put, $"https://discord.com/api/v{Program.discord.GatewayVersion}/guilds/{guildId}/incident-actions");
             setActionsRequest.Headers.Authorization = new AuthenticationHeaderValue("Bot", Environment.GetEnvironmentVariable("CLIPTOK_TOKEN") ?? Program.cfgjson.Core.Token);
             
             setActionsRequest.Content = new StringContent(newSecurityActions, Encoding.UTF8, "application/json");

--- a/Helpers/SecurityActionHelpers.cs
+++ b/Helpers/SecurityActionHelpers.cs
@@ -1,0 +1,25 @@
+namespace Cliptok.Helpers
+{
+    public class SecurityActionHelpers
+    {
+        public static async Task<JToken> GetCurrentSecurityActions(ulong guildId)
+        {
+            using HttpRequestMessage getActionsRequest = new(HttpMethod.Get, $"https://discord.com/api/v9/guilds/{guildId}");
+            getActionsRequest.Headers.Authorization = new AuthenticationHeaderValue("Bot", Environment.GetEnvironmentVariable("CLIPTOK_TOKEN") ?? Program.cfgjson.Core.Token);
+            
+            var getActionsResponse = await Program.httpClient.SendAsync(getActionsRequest);
+            return ((JObject)JsonConvert.DeserializeObject(await getActionsResponse.Content.ReadAsStringAsync()))["incidents_data"];
+        }
+
+        public static async Task<HttpResponseMessage> SetCurrentSecurityActions(ulong guildId, string newSecurityActions)
+        {
+            // create & send request
+            
+            using HttpRequestMessage setActionsRequest = new(HttpMethod.Put, $"https://discord.com/api/v9/guilds/{guildId}/incident-actions");
+            setActionsRequest.Headers.Authorization = new AuthenticationHeaderValue("Bot", Environment.GetEnvironmentVariable("CLIPTOK_TOKEN") ?? Program.cfgjson.Core.Token);
+            
+            setActionsRequest.Content = new StringContent(newSecurityActions, Encoding.UTF8, "application/json");
+            return await Program.httpClient.SendAsync(setActionsRequest);
+        }
+    }
+}


### PR DESCRIPTION
This PR closes #182.

Adds the ability to pause and unpause DMs. This is the same as pausing DMs from a server's "Security Actions" menu:
![image](https://github.com/Erisa/Cliptok/assets/51096169/c77a0918-57a2-4222-9302-f73ebfe175bb)

Because of D#+ limitations, the bot sends manual HTTP requests to Discord's API. It feels a bit hacky, but it works!

'Classic' message commands and slash commands are both added, to both pause DMs:
![image](https://github.com/Erisa/Cliptok/assets/51096169/ab4858eb-cdba-491f-96ca-2e30fbca087b)
...and unpause them:
![image](https://github.com/Erisa/Cliptok/assets/51096169/d16a806a-eb6f-4cbd-8658-5b98a84f2c84)
![image](https://github.com/Erisa/Cliptok/assets/51096169/df31174c-2450-4652-9580-b70c0390190f)

The commands fail with a warning if an invalid time is provided when attempting to pause DMs, or if DMs are already unpaused when attempting to unpause them.
![image](https://github.com/Erisa/Cliptok/assets/51096169/a4a0b53f-3994-4736-bce6-32a5d4761faf)

The slash commands are limited to moderators only (i.e. not trial moderators). Because of limitations, they are restricted with the 'Moderate Members' permission, so they will be visible to trial moderators, but unusable.
![image](https://github.com/Erisa/Cliptok/assets/51096169/33e43d0d-33af-4bb8-8184-c039f7a1256b)
