### PR TITLE
Convert Cyrillic "lookalikes" to Latin characters when checking messages against word filter

### DIFF
--- a/Events/MessageEvent.cs
+++ b/Events/MessageEvent.cs
@@ -194,7 +194,58 @@ namespace Cliptok.Events
                         }
                         else
                         {
-                            (bool success, string flaggedWord) = Checks.ListChecks.CheckForNaughtyWords(message.Content.ToLower(), listItem);
+                            // Map of Cyrillic to Latin characters, to catch attempted bypasses using Cyrillic lookalikes
+                            // <string, string> is <Cyrillic, Latin>
+                            Dictionary<string, string> alphabetMap = new()
+                            {
+                                { "А", "A" },
+                                { "В", "B" },
+                                { "С", "C" },
+                                { "Е", "E" },
+                                { "Ԍ", "G" },
+                                { "Н", "H" },
+                                { "І", "I" },
+                                { "Ӏ", "I" },
+                                { "ӏ", "I" },
+                                { "Ј", "J" },
+                                { "К", "K" },
+                                { "М", "M" },
+                                { "О", "O" },
+                                { "Р", "P" },
+                                { "Ѕ", "S" },
+                                { "Т", "T" },
+                                { "Ѵ", "V" },
+                                { "Ԝ", "W" },
+                                { "Х", "X" },
+                                { "Ү", "Y" },
+                                { "ү", "Y" },
+                                { "а", "a" },
+                                { "Ь", "b" },
+                                { "с", "c" },
+                                { "ԁ", "d" },
+                                { "е", "e" },
+                                { "ҽ", "e" },
+                                { "һ", "h" },
+                                { "і", "i" },
+                                { "ј", "j" },
+                                { "о", "o" },
+                                { "р", "p" },
+                                { "ԛ", "q" },
+                                { "г", "r" },
+                                { "ѕ", "s" },
+                                { "ѵ", "v" },
+                                { "ѡ", "w" },
+                                { "х", "x" },
+                                { "у", "y" },
+                                { "У", "y" }
+                            };
+                            
+                            // Replace any Cyrillic letters found in message with Latin characters, if in the dictionary
+                            string msgContent = message.Content;
+                            foreach (var letter in alphabetMap)
+                                msgContent = msgContent.Replace(letter.Key, letter.Value);
+                            
+                            (bool success, string flaggedWord) = Checks.ListChecks.CheckForNaughtyWords(msgContent.ToLower(), listItem);
                             if (success)
                             {
                                 string reason = listItem.Reason;


### PR DESCRIPTION
This PR closes #197.

Adds a map of some Cyrillic "lookalike" characters to Cliptok's word filter. This allows it to catch a common bypass attempt, where people substitute some Latin characters in their message for Cyrillic ones that look identical or extremely similar.