### PR TITLE
Split /joinwatch into subcommands, minor changes to !joinwatch

### DIFF
--- a/Commands/InteractionCommands/JoinwatchInteractions.cs
+++ b/Commands/InteractionCommands/JoinwatchInteractions.cs
@@ -2,37 +2,91 @@ namespace Cliptok.Commands.InteractionCommands
 {
     internal class JoinwatchInteractions : ApplicationCommandModule
     {
-        [SlashCommand("joinwatch", "Watch for joins and leaves of a given user. Output goes to #investigations.", defaultPermission: false)]
+        [SlashCommandGroup("joinwatch", "Watch for joins and leaves of a given user. Output goes to #investigations.", defaultPermission: false)]
         [SlashRequireHomeserverPerm(ServerPermLevel.TrialModerator)]
-        public async Task JoinwatchSlashCmd(InteractionContext ctx,
-            [Option("user", "The user to watch for joins and leaves of.")] DiscordUser user,
-            [Option("note", "An optional note for context.")] string note = "")
+        public class JoinwatchSlashCmds
         {
-            var joinWatchlist = await Program.db.ListRangeAsync("joinWatchedUsers");
-
-            if (joinWatchlist.Contains(user.Id))
+            [SlashCommand("add", "Watch for joins and leaves of a given user. Output goes to #investigations.")]
+            public async Task JoinwatchAdd(InteractionContext ctx,
+                [Option("user", "The user to watch for joins and leaves of.")] DiscordUser user,
+                [Option("note", "An optional note for context.")] string note = "")
             {
-                if (note != "")
+                var joinWatchlist = await Program.db.ListRangeAsync("joinWatchedUsers");
+
+                if (joinWatchlist.Contains(user.Id))
                 {
-                    // User is already joinwatched, just update note
-                    await Program.db.HashSetAsync("joinWatchedUsersNotes", user.Id, note);
-                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Successfully updated the note for {user.Mention}. Run again with no note to unwatch.");
+                    // User is already watched
+                    
+                    // Get current note; if it's the same, do nothing
+                    var currentNote = await Program.db.HashGetAsync("joinWatchedUsersNotes", user.Id);
+                    if (currentNote == note || (string.IsNullOrWhiteSpace(currentNote) && string.IsNullOrWhiteSpace(note)))
+                    {
+                        await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} {user.Mention} is already being watched with the same note! Nothing to do.");
+                        return;
+                    }
+                    
+                    // If note is different, update it
+                    
+                    // If new note is empty, remove instead of changing to empty string!
+                    if (string.IsNullOrWhiteSpace(note))
+                    {
+                        await Program.db.HashDeleteAsync("joinWatchedUsersNotes", user.Id);
+                        await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Successfully removed the note for {user.Mention}! They are still being watched.");
+                    }
+                    else
+                    {
+                        await Program.db.HashSetAsync("joinWatchedUsersNotes", user.Id, note);
+                        await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Successfully updated the note for {user.Mention}:\n> {note}");   
+                    }
+                }
+                else
+                {
+                    // User is not joinwatched, watch
+                    await Program.db.ListRightPushAsync("joinWatchedUsers", user.Id);
+                    if (note != "")
+                        await Program.db.HashSetAsync("joinWatchedUsersNotes", user.Id, note);
+                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Now watching for joins/leaves of {user.Mention} to send to the investigations channel"
+                        + (note == "" ? "!" : $" with the following note:\n>>> {note}"));
+                }
+            }
+
+            [SlashCommand("remove", "Stop watching for joins and leaves of a user.")]
+            public async Task JoinwatchRemove(InteractionContext ctx,
+                [Option("user", "The user to stop watching for joins and leaves of.")] DiscordUser user)
+            {
+                var joinWatchlist = await Program.db.ListRangeAsync("joinWatchedUsers");
+                
+                // Check user watch status first; error if not watched
+                if (!joinWatchlist.Contains(user.Id))
+                {
+                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} {user.Mention} is not being watched! Nothing to do.");
                     return;
                 }
-
-                // User is already joinwatched, unwatch
+                
                 Program.db.ListRemove("joinWatchedUsers", joinWatchlist.First(x => x == user.Id));
                 await Program.db.HashDeleteAsync("joinWatchedUsersNotes", user.Id);
-                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Successfully unwatched {user.Mention}, since they were already in the list.");
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Successfully unwatched {user.Mention}!");
             }
-            else
+
+            [SlashCommand("status", "Check the joinwatch status for a user.")]
+            public async Task JoinwatchStatus(InteractionContext ctx,
+                [Option("user", "The user whose joinwatch status to check.")] DiscordUser user)
             {
-                // User is not joinwatched, watch
-                await Program.db.ListRightPushAsync("joinWatchedUsers", user.Id);
-                if (note != "")
-                    await Program.db.HashSetAsync("joinWatchedUsersNotes", user.Id, note);
-                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Now watching for joins/leaves of {user.Mention} to send to the investigations channel"
-                    + (note == "" ? "!" : $" with the following note:\n>>> {note}"));
+                var joinWatchlist = await Program.db.ListRangeAsync("joinWatchedUsers");
+                
+                if (joinWatchlist.Contains(user.Id))
+                {
+                    var note = await Program.db.HashGetAsync("joinWatchedUsersNotes", user.Id);
+                    
+                    if (string.IsNullOrWhiteSpace(note))
+                        await ctx.RespondAsync($"{Program.cfgjson.Emoji.Information} {user.Mention} is currently being watched, but no note is set.");
+                    else
+                        await ctx.RespondAsync($"{Program.cfgjson.Emoji.Information} {user.Mention} is currently being watched with the following note:\n> {note}");
+                }
+                else
+                {
+                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} {user.Mention} is not being watched!");
+                }
             }
         }
     }

--- a/Commands/Lists.cs
+++ b/Commands/Lists.cs
@@ -204,9 +204,6 @@
                     
                     // If note is different, update it
                     await Program.db.HashSetAsync("joinWatchedUsersNotes", user.Id, note);
-                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Successfully updated the note for {user.Mention}:\n> {note}");
-                    
-                    await Program.db.HashSetAsync("joinWatchedUsersNotes", user.Id, note);
                     await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Successfully updated the note for {user.Mention} (run again with no note to unwatch):\n> {note}");
                     return;
                 }

--- a/Commands/Lists.cs
+++ b/Commands/Lists.cs
@@ -193,6 +193,19 @@
                 if (note != "")
                 {
                     // User is already joinwatched, just update note
+                    
+                    // Get current note; if it's the same, do nothing
+                    var currentNote = await Program.db.HashGetAsync("joinWatchedUsersNotes", user.Id);
+                    if (currentNote == note || (string.IsNullOrWhiteSpace(currentNote) && string.IsNullOrWhiteSpace(note)))
+                    {
+                        await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} {user.Mention} is already being watched with the same note! Nothing to do.");
+                        return;
+                    }
+                    
+                    // If note is different, update it
+                    await Program.db.HashSetAsync("joinWatchedUsersNotes", user.Id, note);
+                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Successfully updated the note for {user.Mention}:\n> {note}");
+                    
                     await Program.db.HashSetAsync("joinWatchedUsersNotes", user.Id, note);
                     await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Successfully updated the note for {user.Mention} (run again with no note to unwatch):\n> {note}");
                     return;

--- a/Commands/Lists.cs
+++ b/Commands/Lists.cs
@@ -194,7 +194,7 @@
                 {
                     // User is already joinwatched, just update note
                     await Program.db.HashSetAsync("joinWatchedUsersNotes", user.Id, note);
-                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Successfully updated the note for {user.Mention}. Run again with no note to unwatch.");
+                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Successfully updated the note for {user.Mention} (run again with no note to unwatch):\n> {note}");
                     return;
                 }
 


### PR DESCRIPTION
Splits `/joinwatch` into `/joinwatch add`, `/joinwatch status` and `/joinwatch remove`.

`!joinwatch` is also updated—it no longer attempts to update the user's note if it is unchanged (for example, if \<user> was joinwatched with the note "test," using `!joinwatch <user> test` would result in "Successfully updated the note for \<user> ..."; it is now no longer pointlessly overwritten). If the note *is* updated with the `!joinwatch` command, the new note is now shown in the success response.