### PR TITLE
Add /baninfo and /muteinfo

### DIFF
--- a/Commands/InteractionCommands/DebugInteractions.cs
+++ b/Commands/InteractionCommands/DebugInteractions.cs
@@ -108,5 +108,27 @@ namespace Cliptok.Commands.InteractionCommands
         {
             await ctx.RespondAsync(embed: await DiscordHelpers.GenerateUserEmbed(user, ctx.Guild), ephemeral: !publicMessage);
         }
+        
+        [SlashCommand("muteinfo", "Show information about the mute for a user.")]
+        [SlashRequireHomeserverPerm(ServerPermLevel.TrialModerator)]
+        [SlashCommandPermissions(DiscordPermissions.ModerateMembers)]
+        public async Task MuteInfoSlashCommand(
+            InteractionContext ctx,
+            [Option("user", "The user whose mute information to show.")] DiscordUser targetUser,
+            [Option("public", "Whether to show the output publicly. Default: false")] bool isPublic = false)
+        {
+            await ctx.RespondAsync(embed: await MuteHelpers.MuteStatusEmbed(targetUser, ctx.Guild), ephemeral: !isPublic);
+        }
+        
+        [SlashCommand("baninfo", "Show information about the ban for a user.")]
+        [SlashRequireHomeserverPerm(ServerPermLevel.TrialModerator)]
+        [SlashCommandPermissions(DiscordPermissions.ModerateMembers)]
+        public async Task BanInfoSlashCommand(
+            InteractionContext ctx,
+            [Option("user", "The user whose ban information to show.")] DiscordUser targetUser,
+            [Option("public", "Whether to show the output publicly. Default: false")] bool isPublic = false)
+        {
+            await ctx.RespondAsync(embed: await BanHelpers.BanStatusEmbed(targetUser, ctx.Guild), ephemeral: !isPublic);
+        }
     }
 }

--- a/Helpers/BanHelpers.cs
+++ b/Helpers/BanHelpers.cs
@@ -153,5 +153,57 @@
 
         }
 
+        public static async Task<DiscordEmbed> BanStatusEmbed(DiscordUser user, DiscordGuild guild)
+        {
+            DiscordMember member = default;
+            DiscordEmbedBuilder embedBuilder = new();
+            var guildBans = await guild.GetBansAsync();
+            var userBan = guildBans.FirstOrDefault(x => x.User.Id == user.Id);
+
+            embedBuilder.WithFooter(
+                    $"User ID: {user.Id}",
+                    null
+                )
+                .WithAuthor(
+                    $"Ban status for {DiscordHelpers.UniqueUsername(user)}",
+                    null,
+                    await LykosAvatarMethods.UserOrMemberAvatarURL(user, Program.homeGuild, "png")
+                );
+
+            if (await Program.db.HashExistsAsync("bans", user.Id))
+            {
+                MemberPunishment ban = JsonConvert.DeserializeObject<MemberPunishment>(Program.db.HashGet("bans", user.Id));
+                
+                embedBuilder.WithDescription("User is banned.")
+                    .AddField("Banned", ban.ActionTime is null ? "Unknown time (Ban is too old)" : $"<t:{TimeHelpers.ToUnixTimestamp(ban.ActionTime)}:R>", true)
+                    .WithColor(new DiscordColor(0xFEC13D));
+
+                if (ban.ExpireTime is null)
+                    embedBuilder.AddField("Ban expires", "Never", true);
+                else
+                    embedBuilder.AddField("Ban expires", $"<t:{TimeHelpers.ToUnixTimestamp(ban.ExpireTime)}:R>", true);
+
+                embedBuilder.AddField("Banned by", $"<@{ban.ModId}>", true);
+
+                embedBuilder.AddField("Reason", ban.Reason is null ? "No reason provided" : ban.Reason, false);
+            }
+            else
+            {
+                if (userBan is null)
+                {
+                    embedBuilder.WithDescription("User is not banned.")
+                        .WithColor(color: DiscordColor.DarkGreen);
+                }
+                else
+                {
+                    embedBuilder.WithDescription($"User was banned without using {Program.discord.CurrentUser.Username}, so limited information is available.")
+                                            .WithColor(new DiscordColor(0xFEC13D));
+                    embedBuilder.AddField("Reason", string.IsNullOrWhiteSpace(userBan.Reason) ? "No reason provided" : userBan.Reason, false);
+                }
+            }
+
+            return embedBuilder.Build();
+        }
+
     }
 }


### PR DESCRIPTION
This PR closes #199.

Adds two new commands, `/baninfo` and `/muteinfo`. The latter is the same as `c!debug mutestatus`. The former is new and is very similar, but shows info about bans instead of mutes. It fetches data from the db when possible, but for cases where a member was banned and there is no db entry, it gets the ban reason from Discord.

<img width="437" alt="image" src="https://github.com/Erisa/Cliptok/assets/51096169/90c9289f-5cf0-40ec-ba80-428c54395b62">
<img width="553" alt="image" src="https://github.com/Erisa/Cliptok/assets/51096169/8f99d640-f07b-4e7f-83a6-0571a1ddac00">
<img width="962" alt="image" src="https://github.com/Erisa/Cliptok/assets/51096169/74b16f05-6d26-4f23-8736-6ffccddfc588">

(in the last screenshot, that reason would be pulled from Discord—I just didn't set one in Discord either)

These commands have the `public` argument like many other commands do—they default to ephemeral responses, but can have their responses shown publicly if needed.