### PR TITLE
Migrate event handling for D#+ 5.0

### DIFF
--- a/Events/ChannelEvents.cs
+++ b/Events/ChannelEvents.cs
@@ -4,102 +4,99 @@
     {
         public static async Task ChannelUpdated(DiscordClient _, ChannelUpdatedEventArgs e)
         {
-            Task.Run(async () =>
+            // Sync channel overwrites with db so that they can be restored when a user leaves & rejoins.
+
+            // Get the current channel overwrites
+            var currentChannelOverwrites = e.ChannelAfter.PermissionOverwrites;
+
+            // Get the db overwrites
+            var dbOverwrites = await Program.db.HashGetAllAsync("overrides");
+
+            // Compare the two and sync them, prioritizing overwrites on channel over stored overwrites
+
+            foreach (var userOverwrites in dbOverwrites)
             {
-                // Sync channel overwrites with db so that they can be restored when a user leaves & rejoins.
+                var overwriteDict = JsonConvert.DeserializeObject<Dictionary<ulong, DiscordOverwrite>>(userOverwrites.Value);
 
-                // Get the current channel overwrites
-                var currentChannelOverwrites = e.ChannelAfter.PermissionOverwrites;
+                // If the db overwrites are not in the current channel overwrites, remove them from the db.
 
-                // Get the db overwrites
-                var dbOverwrites = await Program.db.HashGetAllAsync("overrides");
-
-                // Compare the two and sync them, prioritizing overwrites on channel over stored overwrites
-
-                foreach (var userOverwrites in dbOverwrites)
+                foreach (var overwrite in overwriteDict)
                 {
-                    var overwriteDict = JsonConvert.DeserializeObject<Dictionary<ulong, DiscordOverwrite>>(userOverwrites.Value);
+                    // (if overwrite is for a different channel, skip)
+                    if (overwrite.Key != e.ChannelAfter.Id) continue;
 
-                    // If the db overwrites are not in the current channel overwrites, remove them from the db.
+                    // (if current overwrite is in the channel, skip)
+                    if (currentChannelOverwrites.Any(a => a == overwrite.Value && e.ChannelAfter.Id == overwrite.Key)) continue;
 
-                    foreach (var overwrite in overwriteDict)
+                    // If it looks like the member left, do NOT remove their overrides.
+
+                    // Delay to allow leave to complete first
+                    await Task.Delay(500);
+
+                    // Try to fetch member. If it fails, they are not in the guild. If this is a voice channel, remove the override.
+                    // (if they are not in the guild & this is not a voice channel, skip; otherwise, code below handles removal)
+                    if (!e.Guild.Members.ContainsKey((ulong)userOverwrites.Name) && e.ChannelAfter.Type != DiscordChannelType.Voice)
+                        continue;
+
+                    // User could be fetched, so they are in the server and their override was removed. Remove from db.
+                    // (or user could not be fetched & this is a voice channel; remove)
+
+                    var overrides = await Program.db.HashGetAsync("overrides", userOverwrites.Name);
+                    var dict = JsonConvert.DeserializeObject<Dictionary<ulong, DiscordOverwrite>>(overrides);
+                    dict.Remove(e.ChannelAfter.Id);
+                    if (dict.Count > 0)
+                        await Program.db.HashSetAsync("overrides", userOverwrites.Name, JsonConvert.SerializeObject(dict));
+                    else
                     {
-                        // (if overwrite is for a different channel, skip)
-                        if (overwrite.Key != e.ChannelAfter.Id) continue;
-
-                        // (if current overwrite is in the channel, skip)
-                        if (currentChannelOverwrites.Any(a => a == overwrite.Value && e.ChannelAfter.Id == overwrite.Key)) continue;
-
-                        // If it looks like the member left, do NOT remove their overrides.
-
-                        // Delay to allow leave to complete first
-                        await Task.Delay(500);
-
-                        // Try to fetch member. If it fails, they are not in the guild. If this is a voice channel, remove the override.
-                        // (if they are not in the guild & this is not a voice channel, skip; otherwise, code below handles removal)
-                        if (!e.Guild.Members.ContainsKey((ulong)userOverwrites.Name) && e.ChannelAfter.Type != DiscordChannelType.Voice)
-                            continue;
-
-                        // User could be fetched, so they are in the server and their override was removed. Remove from db.
-                        // (or user could not be fetched & this is a voice channel; remove)
-
-                        var overrides = await Program.db.HashGetAsync("overrides", userOverwrites.Name);
-                        var dict = JsonConvert.DeserializeObject<Dictionary<ulong, DiscordOverwrite>>(overrides);
-                        dict.Remove(e.ChannelAfter.Id);
-                        if (dict.Count > 0)
-                            await Program.db.HashSetAsync("overrides", userOverwrites.Name, JsonConvert.SerializeObject(dict));
-                        else
-                        {
-                            await Program.db.HashDeleteAsync("overrides", userOverwrites.Name);
-                        }
+                        await Program.db.HashDeleteAsync("overrides", userOverwrites.Name);
                     }
                 }
+            }
 
-                foreach (var overwrite in currentChannelOverwrites)
+            foreach (var overwrite in currentChannelOverwrites)
+            {
+                // Ignore role overrides because we aren't storing those
+                if (overwrite.Type == DiscordOverwriteType.Role) continue;
+
+                // If the current channel overwrites are not in the db, add them to the db.
+
+                if (dbOverwrites
+                    .Select(dbOverwrite => JsonConvert.DeserializeObject<DiscordOverwrite>(dbOverwrite.Value))
+                    .All(dbOverwriteObj => dbOverwriteObj != overwrite))
                 {
-                    // Ignore role overrides because we aren't storing those
-                    if (overwrite.Type == DiscordOverwriteType.Role) continue;
-
-                    // If the current channel overwrites are not in the db, add them to the db.
-
-                    if (dbOverwrites
-                        .Select(dbOverwrite => JsonConvert.DeserializeObject<DiscordOverwrite>(dbOverwrite.Value))
-                        .All(dbOverwriteObj => dbOverwriteObj != overwrite))
+                    if ((await Program.db.HashKeysAsync("overrides")).Any(a => a == overwrite.Id.ToString()))
                     {
-                        if ((await Program.db.HashKeysAsync("overrides")).Any(a => a == overwrite.Id.ToString()))
+                        // User has an overwrite in the db; add this one to their list of overrides without
+                        // touching existing ones
+
+                        var overwrites = await Program.db.HashGetAsync("overrides", overwrite.Id);
+
+                        if (!string.IsNullOrWhiteSpace(overwrites))
                         {
-                            // User has an overwrite in the db; add this one to their list of overrides without
-                            // touching existing ones
+                            var dict = JsonConvert.DeserializeObject<Dictionary<ulong, DiscordOverwrite>>(overwrites);
 
-                            var overwrites = await Program.db.HashGetAsync("overrides", overwrite.Id);
-
-                            if (!string.IsNullOrWhiteSpace(overwrites))
+                            if (dict is not null)
                             {
-                                var dict = JsonConvert.DeserializeObject<Dictionary<ulong, DiscordOverwrite>>(overwrites);
+                                dict.Add(e.ChannelAfter.Id, overwrite);
 
-                                if (dict is not null)
-                                {
-                                    dict.Add(e.ChannelAfter.Id, overwrite);
-
-                                    if (dict.Count > 0)
-                                        await Program.db.HashSetAsync("overrides", overwrite.Id,
-                                            JsonConvert.SerializeObject(dict));
-                                    else
-                                        await Program.db.HashDeleteAsync("overrides", overwrite.Id);
-                                }
+                                if (dict.Count > 0)
+                                    await Program.db.HashSetAsync("overrides", overwrite.Id,
+                                        JsonConvert.SerializeObject(dict));
+                                else
+                                    await Program.db.HashDeleteAsync("overrides", overwrite.Id);
                             }
                         }
-                        else
-                        {
-                            // User doesn't have any overrides in db, so store new dictionary
+                    }
+                    else
+                    {
+                        // User doesn't have any overrides in db, so store new dictionary
 
-                            await Program.db.HashSetAsync("overrides",
-                                overwrite.Id, JsonConvert.SerializeObject(new Dictionary<ulong, DiscordOverwrite>
-                                    { { e.ChannelAfter.Id, overwrite } }));
-                        }
+                        await Program.db.HashSetAsync("overrides",
+                            overwrite.Id, JsonConvert.SerializeObject(new Dictionary<ulong, DiscordOverwrite>
+                                { { e.ChannelAfter.Id, overwrite } }));
                     }
                 }
-            });
+            }
         }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -141,6 +141,29 @@ namespace Cliptok
                 clientConfig.LogUnknownEvents = false;
                 clientConfig.LogUnknownAuditlogs = false;
             });
+            
+            discordBuilder.ConfigureEventHandlers
+            (
+                builder => builder.HandleComponentInteractionCreated(InteractionEvents.ComponentInteractionCreateEvent)
+                                  .HandleSessionCreated(ReadyEvent.OnReady)
+                                  .HandleMessageCreated(MessageEvent.MessageCreated)
+                                  .HandleMessageUpdated(MessageEvent.MessageUpdated)
+                                  .HandleMessageDeleted(MessageEvent.MessageDeleted)
+                                  .HandleGuildMemberAdded(MemberEvents.GuildMemberAdded)
+                                  .HandleGuildMemberRemoved(MemberEvents.GuildMemberRemoved)
+                                  .HandleMessageReactionAdded(ReactionEvent.OnReaction)
+                                  .HandleGuildMemberUpdated(MemberEvents.GuildMemberUpdated)
+                                  .HandleUserUpdated(MemberEvents.UserUpdated)
+                                  .HandleThreadCreated(ThreadEvents.Discord_ThreadCreated)
+                                  .HandleThreadDeleted(ThreadEvents.Discord_ThreadDeleted)
+                                  .HandleThreadListSynced(ThreadEvents.Discord_ThreadListSynced)
+                                  .HandleThreadMemberUpdated(ThreadEvents.Discord_ThreadMemberUpdated)
+                                  .HandleThreadMembersUpdated(ThreadEvents.Discord_ThreadMembersUpdated)
+                                  .HandleHeartbeated(HeartbeatEvent.OnHeartbeat)
+                                  .HandleGuildBanRemoved(UnbanEvent.OnUnban)
+                                  .HandleVoiceStateUpdated(VoiceEvents.VoiceStateUpdate)
+                                  .HandleChannelUpdated(ChannelEvents.ChannelUpdated)
+            );
 
             discord = discordBuilder.Build();
 
@@ -150,29 +173,6 @@ namespace Cliptok
             var slashCommandClasses = Assembly.GetExecutingAssembly().GetTypes().Where(t => t.IsClass && t.Namespace == "Cliptok.Commands.InteractionCommands" && !t.IsNested);
             foreach (var type in slashCommandClasses)
                 slash.RegisterCommands(type, cfgjson.ServerID); ;
-
-            discord.ComponentInteractionCreated += InteractionEvents.ComponentInteractionCreateEvent;
-            discord.SessionCreated += ReadyEvent.OnReady;
-            discord.MessageCreated += MessageEvent.MessageCreated;
-            discord.MessageUpdated += MessageEvent.MessageUpdated;
-            discord.MessageDeleted += MessageEvent.MessageDeleted;
-            discord.GuildMemberAdded += MemberEvents.GuildMemberAdded;
-            discord.GuildMemberRemoved += MemberEvents.GuildMemberRemoved;
-            discord.MessageReactionAdded += ReactionEvent.OnReaction;
-            discord.GuildMemberUpdated += MemberEvents.GuildMemberUpdated;
-            discord.UserUpdated += MemberEvents.UserUpdated;
-            discord.ThreadCreated += ThreadEvents.Discord_ThreadCreated;
-            discord.ThreadDeleted += ThreadEvents.Discord_ThreadDeleted;
-            discord.ThreadListSynced += ThreadEvents.Discord_ThreadListSynced;
-            discord.ThreadMemberUpdated += ThreadEvents.Discord_ThreadMemberUpdated;
-            discord.ThreadMembersUpdated += ThreadEvents.Discord_ThreadMembersUpdated;
-            discord.Heartbeated += HeartbeatEvent.OnHeartbeat;
-
-            discord.GuildBanRemoved += UnbanEvent.OnUnban;
-
-            discord.VoiceStateUpdated += VoiceEvents.VoiceStateUpdate;
-
-            discord.ChannelUpdated += ChannelEvents.ChannelUpdated;
 
             commands = discord.UseCommandsNext(new CommandsNextConfiguration
             {

--- a/Program.cs
+++ b/Program.cs
@@ -141,7 +141,7 @@ namespace Cliptok
                 clientConfig.LogUnknownEvents = false;
                 clientConfig.LogUnknownAuditlogs = false;
             });
-            
+
             discordBuilder.ConfigureEventHandlers
             (
                 builder => builder.HandleComponentInteractionCreated(InteractionEvents.ComponentInteractionCreateEvent)


### PR DESCRIPTION
This PR closes #203.

Changed how event handlers are registered in `Program.cs` to match the new system in D#+ 5.0, and removed a no-longer-necessary `Task.Run(async () => ...` in the Channel Update event handler.

I think this is all we need to do? Events seem to be handled properly when testing.