### PR TITLE
/rules: Add 'public' option

### DIFF
--- a/Commands/InteractionCommands/RulesInteractions.cs
+++ b/Commands/InteractionCommands/RulesInteractions.cs
@@ -106,7 +106,7 @@
             // Returns: true for public response, false for private
             private async Task<bool> DeterminePublicResponse(DiscordMember member, DiscordChannel channel, bool? isPublic)
             {
-                if (Program.cfgjson.RulesAllowedPublicChannels.Contains(channel.Id))
+                if (Program.cfgjson.RulesAllowedPublicChannels.Contains(channel.Id) || Program.cfgjson.RulesAllowedPublicChannels.Contains(channel.Parent.Id))
                 {
                     if (isPublic is null)
                         return true;

--- a/Commands/InteractionCommands/RulesInteractions.cs
+++ b/Commands/InteractionCommands/RulesInteractions.cs
@@ -7,8 +7,10 @@
         internal class RulesSlashCommands
         {
             [SlashCommand("all", "Shows all of the community rules.", defaultPermission: true)]
-            public async Task RulesAllCommand(InteractionContext ctx)
+            public async Task RulesAllCommand(InteractionContext ctx, [Option("public", "Whether to show the response publicly.")] bool? isPublic = null)
             {
+                var publicResponse = await DeterminePublicResponse(ctx.Member, ctx.Channel, isPublic);
+                
                 List<string> rules = default;
 
                 try
@@ -19,7 +21,7 @@
                 catch
                 {
                     // community must be disabled
-                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} I don't see any rules set in Discord for this server!");
+                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} I don't see any rules set in Discord for this server!", ephemeral: !publicResponse);
                     return;
                 }
 
@@ -30,13 +32,15 @@
                     embed.AddField($"Rule {rules.IndexOf(rule) + 1}", rule);
                 }
 
-                await ctx.RespondAsync(embed: embed);
+                await ctx.RespondAsync(embed: embed, ephemeral: !publicResponse);
 
             }
 
             [SlashCommand("rule", "Shows a specific rule.", defaultPermission: true)]
-            public async Task RuleCommand(InteractionContext ctx, [Option("rule_number", "The rule number to show.")] long ruleNumber)
+            public async Task RuleCommand(InteractionContext ctx, [Option("rule_number", "The rule number to show.")] long ruleNumber, [Option("public", "Whether to show the response publicly.")] bool? isPublic = null)
             {
+                var publicResponse = await DeterminePublicResponse(ctx.Member, ctx.Channel, isPublic);   
+                
                 IReadOnlyList<string> rules = default;
 
                 try
@@ -47,24 +51,26 @@
                 catch
                 {
                     // community must be disabled
-                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} I don't see any rules set in Discord for this server!");
+                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} I don't see any rules set in Discord for this server!", ephemeral: !publicResponse);
                     return;
                 }
 
                 if (ruleNumber < 1 || ruleNumber > rules.Count)
                 {
-                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} Rule number must be between 1 and {rules.Count}.");
+                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} Rule number must be between 1 and {rules.Count}.", ephemeral: !publicResponse);
                     return;
                 }
 
                 var embed = new DiscordEmbedBuilder().WithTitle($"Rule {ruleNumber}").WithDescription(rules[(int)ruleNumber - 1]).WithColor(new DiscordColor(0xe4717b));
 
-                await ctx.RespondAsync(embed: embed);
+                await ctx.RespondAsync(embed: embed, ephemeral: !publicResponse);
             }
 
             [SlashCommand("search", "Search for a rule by keyword.", defaultPermission: true)]
-            public async Task RuleSearchCommand(InteractionContext ctx, [Option("keyword", "The keyword to search for.")] string keyword)
+            public async Task RuleSearchCommand(InteractionContext ctx, [Option("keyword", "The keyword to search for.")] string keyword, [Option("public", "Whether to show the response publicly.")] bool? isPublic = null)
             {
+                var publicResponse = await DeterminePublicResponse(ctx.Member, ctx.Channel, isPublic);
+                
                 List<string> rules = default;
 
                 try
@@ -75,7 +81,7 @@
                 catch
                 {
                     // community must be disabled
-                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} I don't see any rules set in Discord for this server!");
+                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} I don't see any rules set in Discord for this server!", ephemeral: !publicResponse);
                     return;
                 }
 
@@ -94,7 +100,29 @@
                     embed.AddField($"Rule {rules.IndexOf(rule) + 1}", rule);
                 }
 
-                await ctx.RespondAsync(embed: embed);
+                await ctx.RespondAsync(embed: embed, ephemeral: !publicResponse);
+            }
+            
+            // Returns: true for public response, false for private
+            private async Task<bool> DeterminePublicResponse(DiscordMember member, DiscordChannel channel, bool? isPublic)
+            {
+                if (Program.cfgjson.RulesAllowedPublicChannels.Contains(channel.Id))
+                {
+                    if (isPublic is null)
+                        return true;
+                    
+                    return isPublic.Value;
+                }
+                
+                if (await GetPermLevelAsync(member) >= ServerPermLevel.TrialModerator)
+                {
+                    if (isPublic is null)
+                        return false;
+                    
+                    return isPublic.Value;
+                }
+                
+                return false;
             }
         }
     }

--- a/Structs.cs
+++ b/Structs.cs
@@ -301,6 +301,9 @@
         
         [JsonProperty("forumChannelAutoWarnFallbackChannel")]
         public ulong ForumChannelAutoWarnFallbackChannel { get; private set; } = 0;
+        
+        [JsonProperty("rulesAllowedPublicChannels")]
+        public List<ulong> RulesAllowedPublicChannels { get; private set; } = new();
     }
 
     public enum Level { Information, Warning, Error, Debug, Verbose }

--- a/config.json
+++ b/config.json
@@ -324,5 +324,13 @@
   "lokiURL": "http://100.79.19.82:3100",
   "lokiServiceName": "cliptok",
   "voiceChannelPurge":  true,
-  "forumChannelAutoWarnFallbackChannel": 150662382874525696
+  "forumChannelAutoWarnFallbackChannel": 150662382874525696,
+  "rulesAllowedPublicChannels": [
+    150909451270881280,
+    1006577277313744996,
+    153165424358457345,
+    740272437719072808,
+    536572162450915340,
+    355973419961155584
+  ]
 }


### PR DESCRIPTION
Closes #228. Adds a `public` option to the `/rules` commands. Behavior changes based on the channel (see cfgjson `rulesAllowedPublicChannels`) and whether the invoking member is a moderator.