### PR TITLE
Feat: Accept timestamps as valid date format for the !remindme command

### DIFF
--- a/Commands/Reminders.cs
+++ b/Commands/Reminders.cs
@@ -36,7 +36,7 @@
             [RemainingText, Description("The text to send when the reminder triggers.")] string reminder
         )
         {
-            string discordTimestampRegexExp = @"^<t:(\d+):[a-z]>$";
+            string discordTimestampRegexExp = @"^<t:(\d+):?\w*>$";
             Match matchesDiscordTimestamp = Regex.Match(timetoParse, discordTimestampRegexExp);
 
 

--- a/Commands/Reminders.cs
+++ b/Commands/Reminders.cs
@@ -52,20 +52,20 @@
             else
             {
                 t = HumanDateParser.HumanDateParser.Parse(timetoParse);
-                if (t <= DateTime.Now)
-                {
-                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} Time can't be in the past!");
-                    return;
-                }
-#if !DEBUG
-                else if (t < (DateTime.Now + TimeSpan.FromSeconds(59)))
-                {
-                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} Time must be at least a minute in the future!");
-                    return;
-                }
-#endif
             }
             
+            if (t <= DateTime.Now)
+            {
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} Time can't be in the past!");
+                return;
+            }
+#if !DEBUG
+            else if (t < (DateTime.Now + TimeSpan.FromSeconds(59)))
+            {
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} Time must be at least a minute in the future!");
+                return;
+            }
+#endif
             
             string guildId;
 


### PR DESCRIPTION
Added support for unix timestamps to the `!remindme` command, so both relative (2w, 1y...) and timestamps work.

Should solve stuff like this : https://discord.com/channels/150662382874525696/717423310308376596/1303016786358435910.

Hope this deploys otherwise rip cliptok ig.