### PR TITLE
Reaction autoremove: Add logging

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -4,5 +4,6 @@ CLIPTOK_ANTIPHISHING_ENDPOINT=useyourimagination
 CLOUDFLARED_TOKEN=ignoreifnotrelevant
 USERNAME_CHECK_ENDPOINT=https://api.example.com/username
 CLIPTALK_WEBHOOK=https://discord.com
+REACTION_LOG_WEBHOOK=https://discord.com
 UPTIME_KUMA_PUSH_URL=
 TS_AUTHKEY=tskey-auth-asdfg-asdfghj

--- a/Events/ReactionEvent.cs
+++ b/Events/ReactionEvent.cs
@@ -24,6 +24,8 @@ namespace Cliptok.Events
                 unban_msg_rx.IsMatch(targetMessage.Content))
             {
                 await targetMessage.DeleteReactionAsync(e.Emoji, e.User);
+                var emoji = e.Emoji.Id != 0 ? $"[{e.Emoji.Name}](<{e.Emoji.Url}>)" : e.Emoji.ToString();
+                await LogChannelHelper.LogMessageAsync("reactions", $"{cfgjson.Emoji.Deleted} Removed reaction {emoji} from [this message]({e.Message.JumpLink}) by {e.User.Mention}");
                 return;
             }
 

--- a/config.json
+++ b/config.json
@@ -287,6 +287,10 @@
     },
     "nicknames": {
       "channelId": 1280688061528674314
+    },
+    "reactions": {
+      "webhookEnvVar": "REACTION_LOG_WEBHOOK",
+      "channelId": 1311084236702482542
     }
   },
   "botOwners": [


### PR DESCRIPTION
Adds logging for auto-removed reactions on warning/mute/ban messages.

Requires the `REACTION_LOG_WEBHOOK` environment variable to be set!