### PR TITLE
Migrate from joinwatch to notes

### DIFF
--- a/Commands/InteractionCommands/JoinwatchInteractions.cs
+++ b/Commands/InteractionCommands/JoinwatchInteractions.cs
@@ -8,24 +8,24 @@ namespace Cliptok.Commands.InteractionCommands
         {
             [SlashCommand("add", "Watch for joins and leaves of a given user. Output goes to #investigations.")]
             public async Task JoinwatchAdd(InteractionContext ctx,
-                [Option("user", "The user to watch for joins and leaves of.")] DiscordUser _,
-                [Option("note", "An optional note for context.")] string __ = "")
+                [Option("user", "The user to watch for joins and leaves of.")] DiscordUser user,
+                [Option("note", "An optional note for context.")] string note = "")
             {
-                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} This command is deprecated and no longer works; all joinwatches have been converted to notes. Please use `/note add` instead, with the `show_on_join_and_leave` option.");
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} This command is deprecated and no longer works; all joinwatches have been converted to notes. Please use `/note add` instead, like this: `/note add user:{user.Id} note:{(string.IsNullOrEmpty(note) ? "<context>" : note)} show_on_join_and_leave:True`");
             }
 
             [SlashCommand("remove", "Stop watching for joins and leaves of a user.")]
             public async Task JoinwatchRemove(InteractionContext ctx,
                 [Option("user", "The user to stop watching for joins and leaves of.")] DiscordUser user)
             {
-                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} This command is deprecated and no longer works; all joinwatches have been converted to notes. Please use `/note remove` instead.");
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} This command is deprecated and no longer works; all joinwatches have been converted to notes. Please use `/note delete` instead, like this: `/note delete user:{user.Id} note:<note>`");
             }
 
             [SlashCommand("status", "Check the joinwatch status for a user.")]
             public async Task JoinwatchStatus(InteractionContext ctx,
                 [Option("user", "The user whose joinwatch status to check.")] DiscordUser user)
             {
-                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} This command is deprecated and no longer works; all joinwatches have been converted to notes. Please use `/note list` or `/note details` instead.");
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} This command is deprecated and no longer works; all joinwatches have been converted to notes. Please use `/note list user:{user.Id}` to show all of this user's notes, or `/note details user:{user.Id} note:<note>` for details on a specific note, instead. Notes with \"Show on Join & Leave\" enabled will behave like joinwatches.");
             }
         }
     }

--- a/Commands/InteractionCommands/JoinwatchInteractions.cs
+++ b/Commands/InteractionCommands/JoinwatchInteractions.cs
@@ -8,85 +8,24 @@ namespace Cliptok.Commands.InteractionCommands
         {
             [SlashCommand("add", "Watch for joins and leaves of a given user. Output goes to #investigations.")]
             public async Task JoinwatchAdd(InteractionContext ctx,
-                [Option("user", "The user to watch for joins and leaves of.")] DiscordUser user,
-                [Option("note", "An optional note for context.")] string note = "")
+                [Option("user", "The user to watch for joins and leaves of.")] DiscordUser _,
+                [Option("note", "An optional note for context.")] string __ = "")
             {
-                var joinWatchlist = await Program.db.ListRangeAsync("joinWatchedUsers");
-
-                if (joinWatchlist.Contains(user.Id))
-                {
-                    // User is already watched
-
-                    // Get current note; if it's the same, do nothing
-                    var currentNote = await Program.db.HashGetAsync("joinWatchedUsersNotes", user.Id);
-                    if (currentNote == note || (string.IsNullOrWhiteSpace(currentNote) && string.IsNullOrWhiteSpace(note)))
-                    {
-                        await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} {user.Mention} is already being watched with the same note! Nothing to do.");
-                        return;
-                    }
-
-                    // If note is different, update it
-
-                    // If new note is empty, remove instead of changing to empty string!
-                    if (string.IsNullOrWhiteSpace(note))
-                    {
-                        await Program.db.HashDeleteAsync("joinWatchedUsersNotes", user.Id);
-                        await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Successfully removed the note for {user.Mention}! They are still being watched.");
-                    }
-                    else
-                    {
-                        await Program.db.HashSetAsync("joinWatchedUsersNotes", user.Id, note);
-                        await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Successfully updated the note for {user.Mention}:\n> {note}");
-                    }
-                }
-                else
-                {
-                    // User is not joinwatched, watch
-                    await Program.db.ListRightPushAsync("joinWatchedUsers", user.Id);
-                    if (note != "")
-                        await Program.db.HashSetAsync("joinWatchedUsersNotes", user.Id, note);
-                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Now watching for joins/leaves of {user.Mention} to send to the investigations channel"
-                        + (note == "" ? "!" : $" with the following note:\n>>> {note}"));
-                }
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} This command is deprecated and no longer works; all joinwatches have been converted to notes. Please use `/note add` instead, with the `show_on_join_and_leave` option.");
             }
 
             [SlashCommand("remove", "Stop watching for joins and leaves of a user.")]
             public async Task JoinwatchRemove(InteractionContext ctx,
                 [Option("user", "The user to stop watching for joins and leaves of.")] DiscordUser user)
             {
-                var joinWatchlist = await Program.db.ListRangeAsync("joinWatchedUsers");
-
-                // Check user watch status first; error if not watched
-                if (!joinWatchlist.Contains(user.Id))
-                {
-                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} {user.Mention} is not being watched! Nothing to do.");
-                    return;
-                }
-
-                Program.db.ListRemove("joinWatchedUsers", joinWatchlist.First(x => x == user.Id));
-                await Program.db.HashDeleteAsync("joinWatchedUsersNotes", user.Id);
-                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Successfully unwatched {user.Mention}!");
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} This command is deprecated and no longer works; all joinwatches have been converted to notes. Please use `/note remove` instead.");
             }
 
             [SlashCommand("status", "Check the joinwatch status for a user.")]
             public async Task JoinwatchStatus(InteractionContext ctx,
                 [Option("user", "The user whose joinwatch status to check.")] DiscordUser user)
             {
-                var joinWatchlist = await Program.db.ListRangeAsync("joinWatchedUsers");
-
-                if (joinWatchlist.Contains(user.Id))
-                {
-                    var note = await Program.db.HashGetAsync("joinWatchedUsersNotes", user.Id);
-
-                    if (string.IsNullOrWhiteSpace(note))
-                        await ctx.RespondAsync($"{Program.cfgjson.Emoji.Information} {user.Mention} is currently being watched, but no note is set.");
-                    else
-                        await ctx.RespondAsync($"{Program.cfgjson.Emoji.Information} {user.Mention} is currently being watched with the following note:\n> {note}");
-                }
-                else
-                {
-                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} {user.Mention} is not being watched!");
-                }
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} This command is deprecated and no longer works; all joinwatches have been converted to notes. Please use `/note list` or `/note details` instead.");
             }
         }
     }

--- a/Commands/InteractionCommands/UserNoteInteractions.cs
+++ b/Commands/InteractionCommands/UserNoteInteractions.cs
@@ -15,7 +15,8 @@ namespace Cliptok.Commands.InteractionCommands
                 [Option("show_on_modmail", "Whether to show the note when the user opens a modmail thread. Default: true")] bool showOnModmail = true,
                 [Option("show_on_warn", "Whether to show the note when the user is warned. Default: true")] bool showOnWarn = true,
                 [Option("show_all_mods", "Whether to show this note to all mods, versus just yourself. Default: true")] bool showAllMods = true,
-                [Option("show_once", "Whether to show this note once and then discard it. Default: false")] bool showOnce = false)
+                [Option("show_once", "Whether to show this note once and then discard it. Default: false")] bool showOnce = false,
+                [Option("show_on_join_and_leave", "Whether to show this note when the user joins & leaves. Works like joinwatch. Default: false")] bool showOnJoinAndLeave = false)
             {
                 await ctx.DeferAsync();
 
@@ -30,6 +31,7 @@ namespace Cliptok.Commands.InteractionCommands
                     ShowOnWarn = showOnWarn,
                     ShowAllMods = showAllMods,
                     ShowOnce = showOnce,
+                    ShowOnJoinAndLeave = showOnJoinAndLeave,
                     NoteId = noteId,
                     Timestamp = DateTime.Now,
                     Type = WarningType.Note
@@ -88,7 +90,8 @@ namespace Cliptok.Commands.InteractionCommands
                 [Option("show_on_modmail", "Whether to show the note when the user opens a modmail thread.")] bool? showOnModmail = null,
                 [Option("show_on_warn", "Whether to show the note when the user is warned.")] bool? showOnWarn = null,
                 [Option("show_all_mods", "Whether to show this note to all mods, versus just yourself.")] bool? showAllMods = null,
-                [Option("show_once", "Whether to show this note once and then discard it.")] bool? showOnce = null)
+                [Option("show_once", "Whether to show this note once and then discard it.")] bool? showOnce = null,
+                [Option("show_on_join_and_leave", "Whether to show this note when the user joins & leaves. Works like joinwatch. Default: false")] bool? showOnJoinAndLeave = false)
             {
                 // Get note
                 UserNote note;
@@ -107,7 +110,7 @@ namespace Cliptok.Commands.InteractionCommands
                     newNoteText = note.NoteText;
 
                 // If no changes are made, refuse the request
-                if (note.NoteText == newNoteText && showOnModmail is null && showOnWarn is null && showAllMods is null && showOnce is null)
+                if (note.NoteText == newNoteText && showOnModmail is null && showOnWarn is null && showAllMods is null && showOnce is null && showOnJoinAndLeave is null)
                 {
                     await ctx.CreateResponseAsync(new DiscordInteractionResponseBuilder().WithContent($"{Program.cfgjson.Emoji.Error} You didn't change anything about the note!").AsEphemeral());
                     return;
@@ -129,6 +132,8 @@ namespace Cliptok.Commands.InteractionCommands
                     showAllMods = note.ShowAllMods;
                 if (showOnce is null)
                     showOnce = note.ShowOnce;
+                if (showOnJoinAndLeave is null)
+                    showOnJoinAndLeave = note.ShowOnJoinAndLeave;
 
                 // Assemble new note
                 note.ModUserId = ctx.User.Id;
@@ -137,6 +142,7 @@ namespace Cliptok.Commands.InteractionCommands
                 note.ShowOnWarn = (bool)showOnWarn;
                 note.ShowAllMods = (bool)showAllMods;
                 note.ShowOnce = (bool)showOnce;
+                note.ShowOnJoinAndLeave = (bool)showOnJoinAndLeave;
                 note.Type = WarningType.Note;
 
                 await Program.db.HashSetAsync(user.Id.ToString(), note.NoteId, JsonConvert.SerializeObject(note));

--- a/Commands/Lists.cs
+++ b/Commands/Lists.cs
@@ -169,11 +169,11 @@
         [HomeServer, RequireHomeserverPerm(ServerPermLevel.TrialModerator)]
         public async Task JoinWatch(
             CommandContext ctx,
-            [Description("The user to watch for joins and leaves of.")] DiscordUser _,
-            [Description("An optional note for context."), RemainingText] string __ = ""
+            [Description("The user to watch for joins and leaves of.")] DiscordUser user,
+            [Description("An optional note for context."), RemainingText] string note = ""
         )
         {
-            await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} This command is deprecated and no longer works; all joinwatches have been converted to notes. Please use `/note add` instead, with the `show_on_join_and_leave` option.");
+            await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} This command is deprecated and no longer works; all joinwatches have been converted to notes. To add a note for this user, please use `/note add user:{user.Id} note:{(string.IsNullOrEmpty(note) ? "<context>" : note)} show_on_join_and_leave:True`; to remove one, use `/note delete user:{user.Id} note:<note>`.");
         }
 
         [Command("appealblock")]

--- a/Commands/Lists.cs
+++ b/Commands/Lists.cs
@@ -169,46 +169,11 @@
         [HomeServer, RequireHomeserverPerm(ServerPermLevel.TrialModerator)]
         public async Task JoinWatch(
             CommandContext ctx,
-            [Description("The user to watch for joins and leaves of.")] DiscordUser user,
-            [Description("An optional note for context."), RemainingText] string note = ""
+            [Description("The user to watch for joins and leaves of.")] DiscordUser _,
+            [Description("An optional note for context."), RemainingText] string __ = ""
         )
         {
-            var joinWatchlist = await Program.db.ListRangeAsync("joinWatchedUsers");
-
-            if (joinWatchlist.Contains(user.Id))
-            {
-                if (note != "")
-                {
-                    // User is already joinwatched, just update note
-
-                    // Get current note; if it's the same, do nothing
-                    var currentNote = await Program.db.HashGetAsync("joinWatchedUsersNotes", user.Id);
-                    if (currentNote == note || (string.IsNullOrWhiteSpace(currentNote) && string.IsNullOrWhiteSpace(note)))
-                    {
-                        await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} {user.Mention} is already being watched with the same note! Nothing to do.");
-                        return;
-                    }
-
-                    // If note is different, update it
-                    await Program.db.HashSetAsync("joinWatchedUsersNotes", user.Id, note);
-                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Successfully updated the note for {user.Mention} (run again with no note to unwatch):\n> {note}");
-                    return;
-                }
-
-                // User is already joinwatched, unwatch
-                Program.db.ListRemove("joinWatchedUsers", joinWatchlist.First(x => x == user.Id));
-                await Program.db.HashDeleteAsync("joinWatchedUsersNotes", user.Id);
-                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Successfully unwatched {user.Mention}, since they were already in the list.");
-            }
-            else
-            {
-                // User is not joinwatched, watch
-                await Program.db.ListRightPushAsync("joinWatchedUsers", user.Id);
-                if (note != "")
-                    await Program.db.HashSetAsync("joinWatchedUsersNotes", user.Id, note);
-                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Now watching for joins/leaves of {user.Mention} to send to the investigations channel"
-                    + (note == "" ? "!" : $" with the following note:\n>>> {note}"));
-            }
+            await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} This command is deprecated and no longer works; all joinwatches have been converted to notes. Please use `/note add` instead, with the `show_on_join_and_leave` option.");
         }
 
         [Command("appealblock")]

--- a/Events/ReadyEvent.cs
+++ b/Events/ReadyEvent.cs
@@ -168,6 +168,15 @@ namespace Cliptok.Events
                     discord.Logger.LogError("Heartbeat ping sent: {status} {content}", (int)response.StatusCode, await response.Content.ReadAsStringAsync());
                 }
             }
+            
+            try
+            {
+                await Migrations.JoinwatchMigration.MigrateJoinwatchesToNotesAsync();
+            }
+            catch (Exception ex)
+            {
+                client.Logger.LogError(ex, "Failed to migrate joinwatches to notes!");
+            }
 
             client.Logger.LogInformation(CliptokEventID, "Startup event complete, logged in as {user}", $"{DiscordHelpers.UniqueUsername(client.CurrentUser)}");
         }

--- a/Helpers/UserNoteHelpers.cs
+++ b/Helpers/UserNoteHelpers.cs
@@ -120,6 +120,7 @@ namespace Cliptok.Helpers
                 .AddField("Show on Warn", note.ShowOnWarn ? "Yes" : "No", true)
                 .AddField("Show all Mods", note.ShowAllMods ? "Yes" : "No", true)
                 .AddField("Show Once", note.ShowOnce ? "Yes" : "No", true)
+                .AddField("Show on Join & Leave", note.ShowOnJoinAndLeave ? "Yes" : "No", true)
                 .AddField("Responsible moderator", $"<@{note.ModUserId}>", true)
                 .AddField("Time", $"<t:{TimeHelpers.ToUnixTimestamp(note.Timestamp)}:f>", true);
 

--- a/Migrations/JoinwatchMigration.cs
+++ b/Migrations/JoinwatchMigration.cs
@@ -7,6 +7,9 @@ namespace Cliptok.Migrations
         public static async Task MigrateJoinwatchesToNotesAsync()
         {
             // Migration from joinwatch to user notes
+            if (!await db.KeyExistsAsync("joinWatchedUsers"))
+                return;
+            
             var joinWatchedUsersList = await Program.db.ListRangeAsync("joinWatchedUsers");
             var joinWatchNotesList = await Program.db.HashGetAllAsync("joinWatchedUsersNotes");
             int successfulMigrations = 0;

--- a/Migrations/JoinwatchMigration.cs
+++ b/Migrations/JoinwatchMigration.cs
@@ -45,9 +45,15 @@ namespace Cliptok.Migrations
                 await db.HashDeleteAsync("joinWatchedUsersNotes", note.TargetUserId);
                 successfulMigrations++;
             }
+            
             if (successfulMigrations > 0)
             {
                 discord.Logger.LogInformation(CliptokEventID, "Successfully migrated {count}/{total} joinwatches to notes.", successfulMigrations, numJoinWatches);
+            }
+            
+            if (numJoinWatches != 0 && successfulMigrations != numJoinWatches)
+            {
+                discord.Logger.LogError(CliptokEventID, "Failed to migrate {count} joinwatches to notes!", numJoinWatches - successfulMigrations);
             }
         }
     }

--- a/Migrations/JoinwatchMigration.cs
+++ b/Migrations/JoinwatchMigration.cs
@@ -1,0 +1,51 @@
+using static Cliptok.Program;
+
+namespace Cliptok.Migrations
+{
+    public class JoinwatchMigration
+    {
+        public static async Task MigrateJoinwatchesToNotesAsync()
+        {
+            // Migration from joinwatch to user notes
+            var joinWatchedUsersList = await Program.db.ListRangeAsync("joinWatchedUsers");
+            var joinWatchNotesList = await Program.db.HashGetAllAsync("joinWatchedUsersNotes");
+            int successfulMigrations = 0;
+            int numJoinWatches = joinWatchedUsersList.Length;
+            foreach (var user in joinWatchedUsersList)
+            {
+                // Get text for note; use joinwatch context if available, or "N/A; imported from joinwatch without context" otherwise
+                string noteText;
+                if (joinWatchNotesList.FirstOrDefault(x => x.Name == user) == default)
+                    noteText = "N/A; imported from joinwatch without context";
+                else
+                    noteText = joinWatchNotesList.First(x => x.Name == user).Value;
+                
+                // Construct note
+                var note = new UserNote
+                {
+                    TargetUserId = Convert.ToUInt64(user),
+                    ModUserId = discord.CurrentUser.Id,
+                    NoteText = noteText,
+                    ShowOnModmail = false,
+                    ShowOnWarn = false,
+                    ShowAllMods = false,
+                    ShowOnce = false,
+                    ShowOnJoinAndLeave = true,
+                    NoteId = db.StringIncrement("totalWarnings"),
+                    Timestamp = DateTime.Now,
+                    Type = WarningType.Note
+                };
+                
+                // Save note & remove joinwatch
+                await db.HashSetAsync(note.TargetUserId.ToString(), note.NoteId, JsonConvert.SerializeObject(note));
+                await db.ListRemoveAsync("joinWatchedUsers", note.TargetUserId);
+                await db.HashDeleteAsync("joinWatchedUsersNotes", note.TargetUserId);
+                successfulMigrations++;
+            }
+            if (successfulMigrations > 0)
+            {
+                discord.Logger.LogInformation(CliptokEventID, "Successfully migrated {count}/{total} joinwatches to notes.", successfulMigrations, numJoinWatches);
+            }
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -233,47 +233,6 @@ namespace Cliptok
 
             await ReadyEvent.OnStartup(discord);
             
-            // Migration from joinwatch to user notes
-            var joinWatchedUsersList = await Program.db.ListRangeAsync("joinWatchedUsers");
-            var joinWatchNotesList = await Program.db.HashGetAllAsync("joinWatchedUsersNotes");
-            int successfulMigrations = 0;
-            int numJoinWatches = joinWatchedUsersList.Length;
-            foreach (var user in joinWatchedUsersList)
-            {
-                // Get text for note; use joinwatch context if available, or "N/A; imported from joinwatch without context" otherwise
-                string noteText;
-                if (joinWatchNotesList.FirstOrDefault(x => x.Name == user) == default)
-                    noteText = "N/A; imported from joinwatch without context";
-                else
-                    noteText = joinWatchNotesList.First(x => x.Name == user).Value;
-                
-                // Construct note
-                var note = new UserNote
-                {
-                    TargetUserId = Convert.ToUInt64(user),
-                    ModUserId = discord.CurrentUser.Id,
-                    NoteText = noteText,
-                    ShowOnModmail = false,
-                    ShowOnWarn = false,
-                    ShowAllMods = false,
-                    ShowOnce = false,
-                    ShowOnJoinAndLeave = true,
-                    NoteId = db.StringIncrement("totalWarnings"),
-                    Timestamp = DateTime.Now,
-                    Type = WarningType.Note
-                };
-                
-                // Save note & remove joinwatch
-                await db.HashSetAsync(note.TargetUserId.ToString(), note.NoteId, JsonConvert.SerializeObject(note));
-                await db.ListRemoveAsync("joinWatchedUsers", note.TargetUserId);
-                await db.HashDeleteAsync("joinWatchedUsersNotes", note.TargetUserId);
-                successfulMigrations++;
-            }
-            if (successfulMigrations > 0)
-            {
-                discord.Logger.LogInformation(CliptokEventID, "Successfully migrated {count}/{total} joinwatches to notes.", successfulMigrations, numJoinWatches);
-            }
-            
             if (cfgjson.ForumChannelAutoWarnFallbackChannel != 0)
                 ForumChannelAutoWarnFallbackChannel = await discord.GetChannelAsync(cfgjson.ForumChannelAutoWarnFallbackChannel);
 

--- a/Program.cs
+++ b/Program.cs
@@ -240,10 +240,10 @@ namespace Cliptok
             int numJoinWatches = joinWatchedUsersList.Length;
             foreach (var user in joinWatchedUsersList)
             {
-                // Get text for note; use joinwatch context if available, or "N/A; created from joinwatch without context" otherwise
+                // Get text for note; use joinwatch context if available, or "N/A; imported from joinwatch without context" otherwise
                 string noteText;
                 if (joinWatchNotesList.FirstOrDefault(x => x.Name == user) == default)
-                    noteText = "N/A; created from joinwatch without context";
+                    noteText = "N/A; imported from joinwatch without context";
                 else
                     noteText = joinWatchNotesList.First(x => x.Name == user).Value;
                 

--- a/Structs.cs
+++ b/Structs.cs
@@ -587,6 +587,9 @@
         [JsonProperty("showOnce")]
         public bool ShowOnce { get; set; }
 
+        [JsonProperty("showOnJoinAndLeave")]
+        public bool ShowOnJoinAndLeave { get; set; }
+
         [JsonProperty("noteId")]
         public long NoteId { get; set; }
 


### PR DESCRIPTION
Moves away from joinwatch in favor of notes:
- Deprecates joinwatch commands
- Adds show on join/leave option to notes
- Migrates joinwatches to notes on bot startup