### PR TITLE
Automatically delete ban messages for compromised account bans

### DIFF
--- a/Commands/Bans.cs
+++ b/Commands/Bans.cs
@@ -207,11 +207,6 @@ namespace Cliptok.Commands
                     return;
                 }
             }
-            reason = reason.Replace("`", "\\`").Replace("*", "\\*");
-            if (banDuration == default)
-                await ctx.Channel.SendMessageAsync($"{Program.cfgjson.Emoji.Banned} {targetMember.Mention} has been banned: **{reason}**");
-            else
-                await ctx.Channel.SendMessageAsync($"{Program.cfgjson.Emoji.Banned} {targetMember.Mention} has been banned for **{TimeHelpers.TimeToPrettyFormat(banDuration, false)}**: **{reason}**");
         }
 
         [Command("unban")]

--- a/Commands/Bans.cs
+++ b/Commands/Bans.cs
@@ -123,11 +123,6 @@ namespace Cliptok.Commands
                     return;
                 }
             }
-            reason = reason.Replace("`", "\\`").Replace("*", "\\*");
-            if (banDuration == default)
-                await ctx.Channel.SendMessageAsync($"{Program.cfgjson.Emoji.Banned} {targetMember.Mention} has been banned: **{reason}**");
-            else
-                await ctx.Channel.SendMessageAsync($"{Program.cfgjson.Emoji.Banned} {targetMember.Mention} has been banned for **{TimeHelpers.TimeToPrettyFormat(banDuration, false)}**: **{reason}**");
         }
 
         /// I CANNOT find a way to do this as alias so I made it a separate copy of the command.

--- a/Commands/Debug.cs
+++ b/Commands/Debug.cs
@@ -131,14 +131,14 @@
                 var msg = await ctx.RespondAsync("Checking for pending scheduled tasks...");
                 bool bans = await Tasks.PunishmentTasks.CheckBansAsync();
                 bool mutes = await Tasks.PunishmentTasks.CheckMutesAsync();
-                bool warns = await Tasks.PunishmentTasks.CheckAutomaticWarningsAsync();
+                bool punishmentMessages = await Tasks.PunishmentTasks.CleanUpPunishmentMessagesAsync();
                 bool reminders = await Tasks.ReminderTasks.CheckRemindersAsync();
                 bool raidmode = await Tasks.RaidmodeTasks.CheckRaidmodeAsync(ctx.Guild.Id);
                 bool unlocks = await Tasks.LockdownTasks.CheckUnlocksAsync();
                 bool channelUpdateEvents = await Tasks.EventTasks.HandlePendingChannelUpdateEventsAsync();
                 bool channelDeleteEvents = await Tasks.EventTasks.HandlePendingChannelDeleteEventsAsync();
 
-                await msg.ModifyAsync($"Unban check result: `{bans}`\nUnmute check result: `{mutes}`\nAutomatic warning message check result: `{warns}`\nReminders check result: `{reminders}`\nRaidmode check result: `{raidmode}`\nUnlocks check result: `{unlocks}`\nPending Channel Update events check result: `{channelUpdateEvents}`\nPending Channel Delete events check result: `{channelDeleteEvents}`");
+                await msg.ModifyAsync($"Unban check result: `{bans}`\nUnmute check result: `{mutes}`\nPunishment message cleanup check result: `{punishmentMessages}`\nReminders check result: `{reminders}`\nRaidmode check result: `{raidmode}`\nUnlocks check result: `{unlocks}`\nPending Channel Update events check result: `{channelUpdateEvents}`\nPending Channel Delete events check result: `{channelDeleteEvents}`");
             }
 
             [Command("sh")]

--- a/Commands/InteractionCommands/BanInteractions.cs
+++ b/Commands/InteractionCommands/BanInteractions.cs
@@ -103,11 +103,6 @@ namespace Cliptok.Commands.InteractionCommands
                     return;
                 }
             }
-            reason = reason.Replace("`", "\\`").Replace("*", "\\*");
-            if (banDuration == default)
-                await ctx.Channel.SendMessageAsync($"{Program.cfgjson.Emoji.Banned} {user.Mention} has been banned: **{reason}**");
-            else
-                await ctx.Channel.SendMessageAsync($"{Program.cfgjson.Emoji.Banned} {user.Mention} has been banned for **{TimeHelpers.TimeToPrettyFormat(banDuration, false)}**: **{reason}**");
 
             webhookOut.Content = $"{Program.cfgjson.Emoji.Success} User was successfully bonked.";
             await ctx.EditResponseAsync(webhookOut);

--- a/Program.cs
+++ b/Program.cs
@@ -249,6 +249,7 @@ namespace Cliptok
                         Tasks.PunishmentTasks.CheckMutesAsync(),
                         Tasks.PunishmentTasks.CheckBansAsync(),
                         Tasks.PunishmentTasks.CheckAutomaticWarningsAsync(),
+                        Tasks.PunishmentTasks.CheckCompromisedAccountBansAsync(),
                         Tasks.ReminderTasks.CheckRemindersAsync(),
                         Tasks.RaidmodeTasks.CheckRaidmodeAsync(cfgjson.ServerID),
                         Tasks.LockdownTasks.CheckUnlocksAsync(),

--- a/Program.cs
+++ b/Program.cs
@@ -248,8 +248,7 @@ namespace Cliptok
                     [
                         Tasks.PunishmentTasks.CheckMutesAsync(),
                         Tasks.PunishmentTasks.CheckBansAsync(),
-                        Tasks.PunishmentTasks.CheckAutomaticWarningsAsync(),
-                        Tasks.PunishmentTasks.CheckCompromisedAccountBansAsync(),
+                        Tasks.PunishmentTasks.CleanUpPunishmentMessagesAsync(),
                         Tasks.ReminderTasks.CheckRemindersAsync(),
                         Tasks.RaidmodeTasks.CheckRaidmodeAsync(cfgjson.ServerID),
                         Tasks.LockdownTasks.CheckUnlocksAsync(),

--- a/Structs.cs
+++ b/Structs.cs
@@ -286,6 +286,9 @@
 
         [JsonProperty("autoWarnMsgAutoDeleteDays")]
         public int AutoWarnMsgAutoDeleteDays { get; private set; }
+        
+        [JsonProperty("compromisedAccountBanMsgAutoDeleteDays")]
+        public int CompromisedAccountBanMsgAutoDeleteDays { get; private set; }
 
         [JsonProperty("logLevel")]
         public Level LogLevel { get; private set; } = Level.Information;

--- a/Tasks/PunishmentTasks.cs
+++ b/Tasks/PunishmentTasks.cs
@@ -77,7 +77,11 @@
                 foreach (KeyValuePair<string, UserWarning> entry in warnList)
                 {
                     UserWarning warn = entry.Value;
+#if DEBUG
                     if (DateTime.Now > warn.WarnTimestamp.AddSeconds(Program.cfgjson.AutoWarnMsgAutoDeleteDays))
+#else
+                    if (DateTime.Now > warn.WarnTimestamp.AddDays(Program.cfgjson.AutoWarnMsgAutoDeleteDays))
+#endif
                     {
                         try
                         {
@@ -106,8 +110,11 @@
                 foreach (KeyValuePair<string, MemberPunishment> entry in banList)
                 {
                     MemberPunishment ban = entry.Value;
-                
+#if DEBUG
                     if (DateTime.Now > ban.ActionTime.Value.AddSeconds(Program.cfgjson.CompromisedAccountBanMsgAutoDeleteDays))
+#else
+                    if (DateTime.Now > ban.ActionTime.Value.AddDays(Program.cfgjson.CompromisedAccountBanMsgAutoDeleteDays))
+#endif
                     {
                         try
                         {

--- a/config.json
+++ b/config.json
@@ -322,6 +322,7 @@
   "tqsMutedRole": 752821045408563230,
   "tqsMuteDurationHours": 2,
   "autoWarnMsgAutoDeleteDays": 3,
+  "compromisedAccountBanMsgAutoDeleteDays": 3,
   "logLevel": "Debug",
   "lokiURL": "http://100.79.19.82:3100",
   "lokiServiceName": "cliptok",


### PR DESCRIPTION
Context: https://discord.com/channels/150662382874525696/780516096335282206/1320441357910675467

Automatically deletes public ban messages for bans for compromised accounts. Time is set in config.json with `compromisedAccountBanMsgAutoDeleteDays`. This works just like #193 with its `autoWarnMsgAutoDeleteDays` config value. This one is also set to 3 days.

As a side effect, this PR also includes `contextMessageReference` and `dmMessageReference` in new ban records now—these were previously not recorded for bans, but `contextMessageReference` was required to get this done so I threw both in. I also moved the code for sending the public ban message into the ban helper—previously it was in the code for each ban command, but it's easier to get `contextMessageReference` into the ban record this way.

This also happens to fix markdown escaping in ban reasons—previously asterisks were escaped in the public chat message but not in member DMs or #mod-logs, but now they are escaped everywhere. 