### PR TITLE
Add support for forwarded messages to autowarn checks

### DIFF
--- a/Events/MessageEvent.cs
+++ b/Events/MessageEvent.cs
@@ -741,7 +741,7 @@ namespace Cliptok.Events
                     }
 
                     // line limit
-                    var lineCount = CountNewlines(message.Content);
+                    var lineCount = CountNewlines(msgContentWithEmbedData);
 
                     if (!Program.cfgjson.LineLimitExcludedChannels.Contains(channel.Id)
                         && (channel.ParentId is null || !Program.cfgjson.LineLimitExcludedChannels.Contains((ulong)channel.ParentId))

--- a/Events/MockDiscordMessage.cs
+++ b/Events/MockDiscordMessage.cs
@@ -20,13 +20,14 @@ namespace Cliptok.Events
             JumpLink = baseMessage.JumpLink;
             MentionedUsers = baseMessage.MentionedUsers;
             MentionedUsersCount = baseMessage.MentionedUsers.Count;
+            MessageSnapshots = baseMessage.MessageSnapshots;
             Reactions = baseMessage.Reactions;
             ReferencedMessage = baseMessage.ReferencedMessage;
             Stickers = baseMessage.Stickers;
             Timestamp = baseMessage.Timestamp;
         }
         
-        public MockDiscordMessage(IReadOnlyList<DiscordAttachment> attachments = default, DiscordUser author = default, DiscordChannel channel = default, ulong channelId = default, string content = default, IReadOnlyList<DiscordEmbed> embeds = default, ulong id = default, Uri jumpLink = default, IReadOnlyList<DiscordUser> mentionedUsers = default, int mentionedUsersCount = default, IReadOnlyList<DiscordReaction> reactions = default, DiscordMessage referencedMessage = default, IReadOnlyList<DiscordMessageSticker> stickers = default, DateTimeOffset? timestamp = default)
+        public MockDiscordMessage(IReadOnlyList<DiscordAttachment> attachments = default, DiscordUser author = default, DiscordChannel channel = default, ulong channelId = default, string content = default, IReadOnlyList<DiscordEmbed> embeds = default, ulong id = default, Uri jumpLink = default, IReadOnlyList<DiscordUser> mentionedUsers = default, int mentionedUsersCount = default, IReadOnlyList<DiscordMessageSnapshot> messageSnapshots = default, IReadOnlyList<DiscordReaction> reactions = default, DiscordMessage referencedMessage = default, IReadOnlyList<DiscordMessageSticker> stickers = default, DateTimeOffset? timestamp = default)
         {
             Attachments = attachments;
             Author = author;
@@ -38,6 +39,7 @@ namespace Cliptok.Events
             JumpLink = jumpLink;
             MentionedUsers = mentionedUsers;
             MentionedUsersCount = mentionedUsersCount;
+            MessageSnapshots = messageSnapshots;
             Reactions = reactions;
             ReferencedMessage = referencedMessage;
             Stickers = stickers;
@@ -55,6 +57,7 @@ namespace Cliptok.Events
         public Uri JumpLink { get; set; }
         public IReadOnlyList<DiscordUser> MentionedUsers { get; }
         public int MentionedUsersCount { get; }
+        public IReadOnlyList<DiscordMessageSnapshot> MessageSnapshots { get; }
         public IReadOnlyList<DiscordReaction> Reactions { get; set; }
         public DiscordMessage ReferencedMessage { get; set; }
         public IReadOnlyList<DiscordMessageSticker> Stickers { get; set; }

--- a/Helpers/InvestigationsHelpers.cs
+++ b/Helpers/InvestigationsHelpers.cs
@@ -6,13 +6,13 @@
         {
             await SendInfringingMessaageAsync(logChannelKey, new MockDiscordMessage(infringingMessage), reason, messageURL, extraField, content, colour, channelOverride);
         }
-        public static async Task SendInfringingMessaageAsync(string logChannelKey, MockDiscordMessage infringingMessage, string reason, string messageURL, (string name, string value, bool inline) extraField = default, string content = default, DiscordColor? colour = null, DiscordChannel channelOverride = default, bool wasAutoModBlock = false)
+        public static async Task SendInfringingMessaageAsync(string logChannelKey, MockDiscordMessage infringingMessage, string reason, string messageURL, (string name, string value, bool inline) extraField = default, string content = default, DiscordColor? colour = null, DiscordChannel channelOverride = default, string messageContentOverride = default, bool wasAutoModBlock = false)
         {
             if (colour is null)
                 colour = new DiscordColor(0xf03916);
 
             var embed = new DiscordEmbedBuilder()
-            .WithDescription(infringingMessage.Content)
+            .WithDescription(string.IsNullOrWhiteSpace(messageContentOverride) ? infringingMessage.Content : messageContentOverride)
             .WithColor((DiscordColor)colour)
             .WithTimestamp(infringingMessage.Timestamp)
             .WithFooter(


### PR DESCRIPTION
Adds support for forwarded messages; their content (& the content of any associated embeds—and embeds that are *not* part of a forwarded message!) are now run through all autowarn checks (I think I got all of them). Forwarded messages are *not* passed through "passive" checks, like looking for CTS pings for #cts-support-feed.

The content of the original message, the content of any forwarded messages, and any text in all embeds are concatenated into a long string that is passed through filters in place of `message.Content`.

Closes #234