### PR TITLE
Add tqsunmute command

### DIFF
--- a/Commands/MuteCmds.cs
+++ b/Commands/MuteCmds.cs
@@ -202,6 +202,91 @@ namespace Cliptok.Commands
             if (ctx is SlashCommandContext)
                 await ctx.EditResponseAsync(new DiscordWebhookBuilder().WithContent("Done. Please open a modmail thread for this user if you haven't already!"));
         }
+        
+        [Command("tqsunmute")]
+        [TextAlias("tqs-unmute", "untqsmute")]
+        [Description("Removes a TQS Mute from a previously TQS-muted user. See also: tqsmute")]
+        [AllowedProcessors(typeof(TextCommandProcessor), typeof(SlashCommandProcessor))]
+        [HomeServer, RequireHomeserverPerm(ServerPermLevel.TechnicalQueriesSlayer)]
+        public async Task TqsUnmuteCmd(CommandContext ctx, [Parameter("user"), Description("The user you're trying to unmute.")] DiscordUser targetUser, [Description("The reason for the unmute.")] string reason)
+        {
+            if (ctx is SlashCommandContext)
+                await ctx.As<SlashCommandContext>().DeferResponseAsync();
+            
+            // only work if TQS mute role is configured
+            if (Program.cfgjson.TqsMutedRole == 0)
+            {
+                if (ctx is SlashCommandContext)
+                    await ctx.EditResponseAsync(new DiscordWebhookBuilder().WithContent($"{Program.cfgjson.Emoji.Error} TQS mutes are not configured, so this command does nothing. Please contact the bot maintainer if this is unexpected."));
+                else
+                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} TQS mutes are not configured, so this command does nothing. Please contact the bot maintainer if this is unexpected.");
+                return;
+            }
+            
+            // Only allow usage in #tech-support, #tech-support-forum, and their threads
+            if (ctx.Channel.Id != Program.cfgjson.TechSupportChannel &&
+                ctx.Channel.Id != Program.cfgjson.SupportForumId &&
+                ctx.Channel.Parent.Id != Program.cfgjson.TechSupportChannel &&
+                ctx.Channel.Parent.Id != Program.cfgjson.SupportForumId)
+            {
+                if (ctx is SlashCommandContext)
+                    await ctx.EditResponseAsync(new DiscordWebhookBuilder().WithContent($"{Program.cfgjson.Emoji.Error} This command can only be used in <#{Program.cfgjson.TechSupportChannel}>, <#{Program.cfgjson.SupportForumId}>, and threads in those channels!"));
+                else
+                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} This command can only be used in <#{Program.cfgjson.TechSupportChannel}>, <#{Program.cfgjson.SupportForumId}>, and threads in those channels!");
+                return;
+            }
+            
+            // Get muted roles
+            DiscordRole mutedRole = await ctx.Guild.GetRoleAsync(Program.cfgjson.MutedRole);
+            DiscordRole tqsMutedRole = await ctx.Guild.GetRoleAsync(Program.cfgjson.TqsMutedRole);
+
+            // Get member
+            DiscordMember targetMember = default;
+            try
+            {
+                targetMember = await ctx.Guild.GetMemberAsync(targetUser.Id);
+            }
+            catch (DSharpPlus.Exceptions.NotFoundException)
+            {
+                // handled below
+            }
+
+            if (await Program.db.HashExistsAsync("mutes", targetUser.Id) && targetMember is not null && targetMember.Roles.Contains(tqsMutedRole))
+            {
+                // If the member has a regular mute, leave the TQS mute alone (it's only a role now & it has no effect if they also have Muted); it will be removed when they are unmuted
+                if (targetMember.Roles.Contains(mutedRole))
+                {
+                    if (ctx is SlashCommandContext)
+                        await ctx.EditResponseAsync($"{Program.cfgjson.Emoji.Error} {targetUser.Mention} has been muted by a Moderator! Their TQS Mute will be removed when the Moderator-issued mute expires.");
+                    else
+                        await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} {targetUser.Mention} has been muted by a Moderator! Their TQS Mute will be removed when the Moderator-issued mute expires.");
+                    return;
+                }
+                
+                // user is TQS-muted; unmute
+                await MuteHelpers.UnmuteUserAsync(targetUser, reason, true, ctx.User, true);
+                if (ctx is SlashCommandContext)
+                    await ctx.EditResponseAsync($"{Program.cfgjson.Emoji.Success} Successfully unmuted {targetUser.Mention}!");
+                else
+                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Successfully unmuted {targetUser.Mention}!");
+            }
+            else if (targetMember is null)
+            {
+                // couldn't fetch member, fail
+                if (ctx is SlashCommandContext)
+                    await ctx.EditResponseAsync($"{Program.cfgjson.Emoji.Error} That user doesn't appear to be in the server!");
+                else
+                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} That user doesn't appear to be in the server!");
+            }
+            else
+            {
+                // member is not TQS-muted, fail
+                if (ctx is SlashCommandContext)
+                    await ctx.EditResponseAsync($"{Program.cfgjson.Emoji.Error} That user doesn't appear to be TQS-muted!");
+                else
+                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} That user doesn't appear to be TQS-muted!");
+            }
+        }
 
         [Command("muteinfo")]
         [Description("Show information about the mute for a user.")]
@@ -223,8 +308,6 @@ namespace Cliptok.Commands
         [HomeServer, RequireHomeserverPerm(ServerPermLevel.TrialModerator)]
         public async Task UnmuteCmd(TextCommandContext ctx, [Description("The user you're trying to unmute.")] DiscordUser targetUser, string reason = "No reason provided.")
         {
-            reason = $"[Manual unmute by {DiscordHelpers.UniqueUsername(ctx.User)}]: {reason}";
-
             // todo: store per-guild
             DiscordRole mutedRole = await ctx.Guild.GetRoleAsync(Program.cfgjson.MutedRole);
             DiscordRole tqsMutedRole = default;

--- a/Commands/MuteCmds.cs
+++ b/Commands/MuteCmds.cs
@@ -223,16 +223,17 @@ namespace Cliptok.Commands
                 return;
             }
             
-            // Only allow usage in #tech-support, #tech-support-forum, and their threads
+            // Only allow usage in #tech-support, #tech-support-forum, and their threads + #bot-commands
             if (ctx.Channel.Id != Program.cfgjson.TechSupportChannel &&
                 ctx.Channel.Id != Program.cfgjson.SupportForumId &&
                 ctx.Channel.Parent.Id != Program.cfgjson.TechSupportChannel &&
-                ctx.Channel.Parent.Id != Program.cfgjson.SupportForumId)
+                ctx.Channel.Parent.Id != Program.cfgjson.SupportForumId &&
+                ctx.Channel.Id != Program.cfgjson.BotCommandsChannel)
             {
                 if (ctx is SlashCommandContext)
                     await ctx.EditResponseAsync(new DiscordWebhookBuilder().WithContent($"{Program.cfgjson.Emoji.Error} This command can only be used in <#{Program.cfgjson.TechSupportChannel}>, <#{Program.cfgjson.SupportForumId}>, and threads in those channels!"));
                 else
-                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} This command can only be used in <#{Program.cfgjson.TechSupportChannel}>, <#{Program.cfgjson.SupportForumId}>, and threads in those channels!");
+                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} This command can only be used in <#{Program.cfgjson.TechSupportChannel}>, <#{Program.cfgjson.SupportForumId}>, their threads, and <#{Program.cfgjson.BotCommandsChannel}>!");
                 return;
             }
             
@@ -248,7 +249,12 @@ namespace Cliptok.Commands
             }
             catch (DSharpPlus.Exceptions.NotFoundException)
             {
-                // handled below
+                // couldn't fetch member, fail
+                if (ctx is SlashCommandContext)
+                    await ctx.EditResponseAsync($"{Program.cfgjson.Emoji.Error} That user doesn't appear to be in the server!");
+                else
+                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} That user doesn't appear to be in the server!");
+                return;
             }
 
             if (await Program.db.HashExistsAsync("mutes", targetUser.Id) && targetMember is not null && targetMember.Roles.Contains(tqsMutedRole))
@@ -269,14 +275,6 @@ namespace Cliptok.Commands
                     await ctx.EditResponseAsync($"{Program.cfgjson.Emoji.Success} Successfully unmuted {targetUser.Mention}!");
                 else
                     await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Successfully unmuted {targetUser.Mention}!");
-            }
-            else if (targetMember is null)
-            {
-                // couldn't fetch member, fail
-                if (ctx is SlashCommandContext)
-                    await ctx.EditResponseAsync($"{Program.cfgjson.Emoji.Error} That user doesn't appear to be in the server!");
-                else
-                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} That user doesn't appear to be in the server!");
             }
             else
             {

--- a/Structs.cs
+++ b/Structs.cs
@@ -336,6 +336,9 @@
 
         [JsonProperty("githubWorkflowSucessString")]
         public string GithubWorkflowSucessString { get; private set; } = "";
+        
+        [JsonProperty("botCommandsChannel")]
+        public ulong BotCommandsChannel { get; private set; }
     }
 
     public enum Level { Information, Warning, Error, Debug, Verbose }

--- a/config.json
+++ b/config.json
@@ -348,5 +348,6 @@
     450181490345508884
   ],
   "pingBotOwnersOnBadErrors": true,
-  "githubWorkflowSucessString": "[lists:main] 1 new commit"
+  "githubWorkflowSucessString": "[lists:main] 1 new commit",
+  "botCommandsChannel": 740272437719072808
 }


### PR DESCRIPTION
Adds a new tqsunmute command. Closes #273 

Unlike with the standard unmute command, tqsunmute requires a reason to be provided for the unmute. It also logs the reason to the mod log channel in addition to the audit log. **As a side effect, this changes how reasons are passed to `UnmuteUserAsync`!** Previously the entire Audit Log reason (`[Manual unmute by floatingmilkshake]: some reason`) was passed to the helper function; now you should only pass the actual reason (just `some reason`) and the helper will add the part in brackets to *only* the Audit Log entry.

This command will refuse to unmute the user if:
- They are missing the TQS Muted role
- They have the Muted role (so they were given a regular mute later; redis entry was overwritten anyway, both roles will be removed on unmute)
- They are missing a mute entry in redis (so they aren't muted at all, or maybe they are—but this isn't a TQS mute anyway)*
- They cannot be fetched (if the member isn't in the server, we can't verify whether they have/had the TQS Muted role—I'd rather not guess based on mute details, and there is no "is TQS Mute" flag on mute data in redis)

*In hindsight it's possible for a member to have the TQS Muted role without a mute entry if the role is manually assigned or something, but that isn't likely and isn't really important enough to bother with so I don't really care enough to handle it