### PR TITLE
Move !editannounce to slash command

### DIFF
--- a/Commands/AnnouncementCmds.cs
+++ b/Commands/AnnouncementCmds.cs
@@ -296,7 +296,7 @@ namespace Cliptok.Commands
             
             if (msg.Author.Id != ctx.Client.CurrentUser.Id)
             {
-                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} That message ID wasn't recognised!", ephemeral: true);
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} That message wasn't sent by me, so I can't edit it!", ephemeral: true);
                 return;
             }
             

--- a/Commands/AnnouncementCmds.cs
+++ b/Commands/AnnouncementCmds.cs
@@ -467,7 +467,10 @@ namespace Cliptok.Commands
                 List<DiscordApplicationCommandOptionChoice> list = new();
                 foreach (var role in Program.cfgjson.AnnouncementRoles)
                 {
-                    list.Add(new DiscordApplicationCommandOptionChoice(Program.cfgjson.AnnouncementRolesFriendlyNames[role.Key], role.Key));
+                    if (Program.cfgjson.AnnouncementRolesFriendlyNames is not null && Program.cfgjson.AnnouncementRolesFriendlyNames.ContainsKey(role.Key))
+                        list.Add(new DiscordApplicationCommandOptionChoice(Program.cfgjson.AnnouncementRolesFriendlyNames[role.Key], role.Key));
+                    else
+                        list.Add(new DiscordApplicationCommandOptionChoice(role.Key, role.Key));
                 }
                 return list;
             }

--- a/Commands/AnnouncementCmds.cs
+++ b/Commands/AnnouncementCmds.cs
@@ -275,8 +275,10 @@ namespace Cliptok.Commands
         public async Task EditAnnounce(
             SlashCommandContext ctx,
             [Parameter("message"), Description("The ID of the message to edit.")] string messageId,
-            [Parameter("role1"), Description("The short name for the first role to ping.")] string role1Name,
-            [Parameter("role2"), Description("The short name for the second role to ping. Optional.")] string role2Name = null
+            [SlashChoiceProvider(typeof(AnnouncementRoleChoiceProvider))]
+            [Parameter("role1"), Description("The first role to ping.")] string role1Name,
+            [SlashChoiceProvider(typeof(AnnouncementRoleChoiceProvider))]
+            [Parameter("role2"), Description("The second role to ping. Optional.")] string role2Name = null
         )
         {
             // Validate msg ID
@@ -311,7 +313,7 @@ namespace Cliptok.Commands
             
             EditAnnounceCache = (Convert.ToUInt64(messageId), role1Name, role2Name);
 
-            await ctx.RespondWithModalAsync(new DiscordInteractionResponseBuilder().WithTitle("Edit Announcement").WithCustomId("editannounce-modal-callback").AddComponents(new DiscordTextInputComponent("New announcement text. Do not include roles!", "editannounce-modal-new-text", value: Regex.Replace(msg.Content, Constants.RegexConstants.role_rx.ToString(), ""), style: DiscordTextInputStyle.Paragraph)));
+            await ctx.RespondWithModalAsync(new DiscordInteractionResponseBuilder().WithTitle("Edit Announcement").WithCustomId("editannounce-modal-callback").AddComponents(new DiscordTextInputComponent("New announcement text. Do not include roles!", "editannounce-modal-new-text", value: msg.Content, style: DiscordTextInputStyle.Paragraph)));
         }
 
         [Command("announcetextcmd")]
@@ -454,6 +456,19 @@ namespace Cliptok.Commands
                     new("Beta Channel", "Beta"),
                     new("Release Preview Channel", "RP")
                 };
+            }
+        }
+        
+        internal class AnnouncementRoleChoiceProvider : IChoiceProvider
+        {
+            public async ValueTask<IEnumerable<DiscordApplicationCommandOptionChoice>> ProvideAsync(CommandParameter _)
+            {
+                List<DiscordApplicationCommandOptionChoice> list = new();
+                foreach (var role in Program.cfgjson.AnnouncementRoles)
+                {
+                    list.Add(new DiscordApplicationCommandOptionChoice(Program.cfgjson.AnnouncementRolesFriendlyNames[role.Key], role.Key));
+                }
+                return list;
             }
         }
     }

--- a/Commands/AnnouncementCmds.cs
+++ b/Commands/AnnouncementCmds.cs
@@ -3,7 +3,8 @@ namespace Cliptok.Commands
     public class AnnouncementCmds
     {
         // used to pass context to modal handling for /editannounce
-        public static (ulong msgId, string role1, string role2) EditAnnounceCache;
+        // keyed by user ID
+        public static Dictionary<ulong, (ulong msgId, string role1, string role2)> EditAnnounceCache = new();
         
         [Command("announcebuild")]
         [Description("Announce a Windows Insider build in the current channel.")]
@@ -311,7 +312,7 @@ namespace Cliptok.Commands
                 return;
             }
             
-            EditAnnounceCache = (Convert.ToUInt64(messageId), role1Name, role2Name);
+            EditAnnounceCache[ctx.User.Id] = (Convert.ToUInt64(messageId), role1Name, role2Name);
 
             await ctx.RespondWithModalAsync(new DiscordInteractionResponseBuilder().WithTitle("Edit Announcement").WithCustomId("editannounce-modal-callback").AddComponents(new DiscordTextInputComponent("New announcement text. Do not include roles!", "editannounce-modal-new-text", value: msg.Content, style: DiscordTextInputStyle.Paragraph)));
         }

--- a/Commands/AnnouncementCmds.cs
+++ b/Commands/AnnouncementCmds.cs
@@ -2,6 +2,9 @@ namespace Cliptok.Commands
 {
     public class AnnouncementCmds
     {
+        // used to pass context to modal handling for /editannounce
+        public static (ulong msgId, string role1, string role2) EditAnnounceCache;
+        
         [Command("announcebuild")]
         [Description("Announce a Windows Insider build in the current channel.")]
         [AllowedProcessors(typeof(SlashCommandProcessor))]
@@ -265,41 +268,50 @@ namespace Cliptok.Commands
             }
         }
 
-        [Command("editannouncetextcmd")]
-        [TextAlias("editannounce")]
+        [Command("editannounce")]
         [Description("Edit an announcement, preserving the ping highlight.")]
-        [AllowedProcessors(typeof(TextCommandProcessor))]
+        [AllowedProcessors(typeof(SlashCommandProcessor))]
         [RequireHomeserverPerm(ServerPermLevel.Moderator)]
         public async Task EditAnnounce(
-            TextCommandContext ctx,
-            [Description("The ID of the message to edit.")] ulong messageId,
-            [Description("The short name for the role to ping.")] string roleName,
-            [RemainingText, Description("The new message content, excluding the ping.")] string content
+            SlashCommandContext ctx,
+            [Parameter("message"), Description("The ID of the message to edit.")] string messageId,
+            [Parameter("role1"), Description("The short name for the first role to ping.")] string role1Name,
+            [Parameter("role2"), Description("The short name for the second role to ping. Optional.")] string role2Name = null
         )
         {
-            DiscordRole discordRole;
-
-            if (Program.cfgjson.AnnouncementRoles.ContainsKey(roleName))
+            // Validate msg ID
+            DiscordMessage msg;
+            try
             {
-                discordRole = await ctx.Guild.GetRoleAsync(Program.cfgjson.AnnouncementRoles[roleName]);
-                await discordRole.ModifyAsync(mentionable: true);
-                try
-                {
-                    await ctx.Message.DeleteAsync();
-                    var msg = await ctx.Channel.GetMessageAsync(messageId);
-                    await msg.ModifyAsync($"{discordRole.Mention} {content}");
-                }
-                catch
-                {
-                    // We still need to remember to make it unmentionable even if the msg fails.
-                }
-                await discordRole.ModifyAsync(mentionable: false);
+                msg = await ctx.Channel.GetMessageAsync(Convert.ToUInt64(messageId));
             }
-            else
+            catch
             {
-                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} That role name isn't recognised!");
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} That message ID wasn't recognised!", ephemeral: true);
                 return;
             }
+            
+            if (msg.Author.Id != ctx.Client.CurrentUser.Id)
+            {
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} That message ID wasn't recognised!", ephemeral: true);
+                return;
+            }
+            
+            // Validate roles
+            if (!Program.cfgjson.AnnouncementRoles.ContainsKey(role1Name) || (role2Name is not null && !Program.cfgjson.AnnouncementRoles.ContainsKey(role2Name)))
+            {
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} The role name(s) you entered aren't recognised!", ephemeral: true);
+                return;
+            }
+            if (role1Name == role2Name)
+            {
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Warning} You provided the same role name twice! Did you mean to use two different roles?", ephemeral: true);
+                return;
+            }
+            
+            EditAnnounceCache = (Convert.ToUInt64(messageId), role1Name, role2Name);
+
+            await ctx.RespondWithModalAsync(new DiscordInteractionResponseBuilder().WithTitle("Edit Announcement").WithCustomId("editannounce-modal-callback").AddComponents(new DiscordTextInputComponent("New announcement text. Do not include roles!", "editannounce-modal-new-text", value: Regex.Replace(msg.Content, Constants.RegexConstants.role_rx.ToString(), ""), style: DiscordTextInputStyle.Paragraph)));
         }
 
         [Command("announcetextcmd")]

--- a/Constants/RegexConstants.cs
+++ b/Constants/RegexConstants.cs
@@ -10,6 +10,7 @@
         readonly public static Regex discord_link_rx = new(@".*discord(?:app)?.com\/channels\/((?:@)?[a-z0-9]*)\/([0-9]*)(?:\/)?([0-9]*)");
         readonly public static Regex channel_rx = new("<#([0-9]+)>");
         readonly public static Regex user_rx = new("<@([0-9]+)>");
+        readonly public static Regex role_rx = new("<@&([0-9]+)>");
         readonly public static Regex warn_msg_rx = new($"{Program.cfgjson.Emoji.Warning} <@!?[0-9]+> was warned");
         readonly public static Regex auto_warn_msg_rx = new($"{Program.cfgjson.Emoji.Denied} <@!?[0-9]+> was automatically warned");
         readonly public static Regex mute_msg_rx = new($"{Program.cfgjson.Emoji.Muted} <@!?[0-9]+> has been muted");

--- a/Events/InteractionEvents.cs
+++ b/Events/InteractionEvents.cs
@@ -407,6 +407,47 @@ namespace Cliptok.Events
             }
 
         }
+        
+        public static async Task ModalSubmitted(DiscordClient _, ModalSubmittedEventArgs e)
+        {
+            if (e.Id == "editannounce-modal-callback")
+            {
+                // Get roles & make mentionable
+                var ctx = Commands.AnnouncementCmds.EditAnnounceCache;
+                DiscordRole role1 = await e.Interaction.Guild.GetRoleAsync(Program.cfgjson.AnnouncementRoles[ctx.role1]);
+                await role1.ModifyAsync(mentionable: true);
+                
+                DiscordRole role2 = null;
+                if (ctx.role2 is not null)
+                {
+                    role2 = await e.Interaction.Guild.GetRoleAsync(Program.cfgjson.AnnouncementRoles[ctx.role2]);
+                    await role2.ModifyAsync(mentionable: true);
+                }
+                
+                try
+                {
+                    var msg = await e.Interaction.Channel.GetMessageAsync(ctx.msgId);
+                    string content = role1.Mention;
+                    if (role2 is not null)
+                        content += $" {role2.Mention}";
+                    content += $" {e.Values["editannounce-modal-new-text"]}";
+                    await msg.ModifyAsync(new DiscordMessageBuilder().WithContent(content).WithAllowedMentions(Mentions.All));
+                    
+                    await e.Interaction.CreateResponseAsync(DiscordInteractionResponseType.ChannelMessageWithSource, new DiscordInteractionResponseBuilder().WithContent($"{Program.cfgjson.Emoji.Success} Done!").AsEphemeral(true));
+                }
+                catch
+                {
+                    // We still need to remember to make it unmentionable even if the msg fails.
+                }
+                await role1.ModifyAsync(mentionable: false);
+                if (role2 is not null)
+                    await role2.ModifyAsync(mentionable: false);
+            }
+            else
+            {
+                await e.Interaction.CreateResponseAsync(DiscordInteractionResponseType.ChannelMessageWithSource, new DiscordInteractionResponseBuilder().WithContent("Unknown interaction. I don't know what you are asking me for.").AsEphemeral(true));
+            }
+        }
 
         public static async Task SlashCommandErrored(CommandErroredEventArgs e)
         {

--- a/Events/InteractionEvents.cs
+++ b/Events/InteractionEvents.cs
@@ -427,10 +427,14 @@ namespace Cliptok.Events
                 try
                 {
                     var msg = await e.Interaction.Channel.GetMessageAsync(ctx.msgId);
-                    string content = role1.Mention;
-                    if (role2 is not null)
-                        content += $" {role2.Mention}";
-                    content += $" {e.Values["editannounce-modal-new-text"]}";
+                    
+                    // Set up content, add role mentions if they arent anywhere else in the content already
+                    string content = e.Values["editannounce-modal-new-text"];
+                    if (role2 is not null && !content.Contains(role2.Id.ToString()))
+                        content = $"{role2.Mention} {content}";
+                    if (!content.Contains(role1.Id.ToString()))
+                        content = $"{role1.Mention} {content}";
+                    
                     await msg.ModifyAsync(new DiscordMessageBuilder().WithContent(content).WithAllowedMentions(Mentions.All));
                     
                     await e.Interaction.CreateResponseAsync(DiscordInteractionResponseType.ChannelMessageWithSource, new DiscordInteractionResponseBuilder().WithContent($"{Program.cfgjson.Emoji.Success} Done!").AsEphemeral(true));
@@ -445,7 +449,8 @@ namespace Cliptok.Events
             }
             else
             {
-                await e.Interaction.CreateResponseAsync(DiscordInteractionResponseType.ChannelMessageWithSource, new DiscordInteractionResponseBuilder().WithContent("Unknown interaction. I don't know what you are asking me for.").AsEphemeral(true));
+                await e.Interaction.CreateResponseAsync(DiscordInteractionResponseType.ChannelMessageWithSource, new DiscordInteractionResponseBuilder().WithContent($"{Program.cfgjson.Emoji.Error} Unknown interaction! This should never happen. Please contact the bot owner(s)!").AsEphemeral(true));
+                Program.discord.Logger.LogError(Program.CliptokEventID, "Received unexpected modal submission with ID {id}!", e.Id);
             }
         }
 

--- a/Events/InteractionEvents.cs
+++ b/Events/InteractionEvents.cs
@@ -413,7 +413,7 @@ namespace Cliptok.Events
             if (e.Id == "editannounce-modal-callback")
             {
                 // Get roles & make mentionable
-                var ctx = Commands.AnnouncementCmds.EditAnnounceCache;
+                var ctx = Commands.AnnouncementCmds.EditAnnounceCache[e.Interaction.User.Id];
                 DiscordRole role1 = await e.Interaction.Guild.GetRoleAsync(Program.cfgjson.AnnouncementRoles[ctx.role1]);
                 await role1.ModifyAsync(mentionable: true);
                 

--- a/Program.cs
+++ b/Program.cs
@@ -211,6 +211,7 @@ namespace Cliptok
             discordBuilder.ConfigureEventHandlers
             (
                 builder => builder.HandleComponentInteractionCreated(InteractionEvents.ComponentInteractionCreateEvent)
+                                  .HandleModalSubmitted(InteractionEvents.ModalSubmitted)
                                   .HandleSessionCreated(ReadyEvent.OnReady)
                                   .HandleMessageCreated(MessageEvent.MessageCreated)
                                   .HandleMessageUpdated(MessageEvent.MessageUpdated)

--- a/Structs.cs
+++ b/Structs.cs
@@ -187,6 +187,9 @@
 
         [JsonProperty("announcementRoles")]
         public Dictionary<string, ulong> AnnouncementRoles { get; private set; }
+        
+        [JsonProperty("announcementRolesFriendlyNames")]
+        public Dictionary<string, string> AnnouncementRolesFriendlyNames { get; private set; }
 
         [JsonProperty("hastebinEndpoint")]
         public string HastebinEndpoint { get; private set; }

--- a/config.json
+++ b/config.json
@@ -23,6 +23,14 @@
     "rp10": 910319453491839069,
     "patch": 445773142233710594
   },
+  "announcementRolesFriendlyNames": {
+    "canary": "Windows 11 Insiders (Canary)",
+    "dev": "Windows 11 Insiders (Dev)",
+    "beta": "Windows 11 Insiders (Beta)",
+    "rp": "Windows 11 Insiders (Release Preview)",
+    "rp10": "Windows 10 Insiders (Release Preview)",
+    "patch": "Patch Tuesday"
+  },
   "appealLink": "https://appeal.msft.chat",
   "inviteExclusion": [
     "microsoft",


### PR DESCRIPTION
Moves !editannounce to a slash command. Closes #276

Slash command accepts a message ID for the announcement to edit (so must be in the same channel) + role IDs to mention. If all are valid, a modal is opened to accept updated announcement text (and it is pre-filled with the current text minus any role mentions).