### PR TITLE
Add !editban and !editmute

### DIFF
--- a/Commands/PunishmentHelpers.cs
+++ b/Commands/PunishmentHelpers.cs
@@ -1,0 +1,42 @@
+namespace Cliptok.Commands
+{
+    public class PunishmentHelpers
+    {
+        public static (TimeSpan duration, string reason, bool appealable) UnpackTimeAndReason(string timeAndReason, DateTime anchorTime)
+        {
+            TimeSpan duration = default;
+            bool appealable = false;
+            bool timeParsed = false;
+
+            string possibleTime = timeAndReason.Split(' ').First();
+            try
+            {
+                duration = HumanDateParser.HumanDateParser.Parse(possibleTime).Subtract(anchorTime);
+                timeParsed = true;
+            }
+            catch
+            {
+                // keep default
+            }
+
+            string reason = timeAndReason;
+
+            if (timeParsed)
+            {
+                int i = reason.IndexOf(" ") + 1;
+                reason = reason[i..];
+            }
+
+            if (timeParsed && possibleTime == reason)
+                reason = "No reason specified.";
+
+            if (reason.Length > 6 && reason[..7].ToLower() == "appeal ")
+            {
+                appealable = true;
+                reason = reason[7..^0];
+            }
+
+            return (duration, reason, appealable);
+        }
+    }
+}


### PR DESCRIPTION
Closes #144!

Adds !editban and !editmute. Syntax is exactly the same as !ban(keep) and !mute.

Editing a ban or mute will change the responsible moderator (open to changing this, I just stole the behavior from !editwarn) and edit the DM & chat message (and anything else changed, like expire time, reason, appeal). The `actionTime` is left unchanged.

Edits are logged to the `mod` log channel:

![image](https://github.com/user-attachments/assets/95f02e6b-836a-414c-b024-eb51af2d5de5)

![image](https://github.com/user-attachments/assets/06b1beb5-58de-41d6-9de9-02066ae3d597)

![image](https://github.com/user-attachments/assets/85bbdcfa-56b8-490d-a02e-ce2c10e46e2b)