### PR TITLE
Add !revoke & temporary reactions to delete warnings from log channels

### DIFF
--- a/Constants/RegexConstants.cs
+++ b/Constants/RegexConstants.cs
@@ -17,5 +17,6 @@
         readonly public static Regex unmute_msg_rx = new($"{Program.cfgjson.Emoji.Information} Successfully unmuted");
         readonly public static Regex ban_msg_rx = new($"{Program.cfgjson.Emoji.Banned} <@!?[0-9]+> has been banned");
         readonly public static Regex unban_msg_rx = new($"{Program.cfgjson.Emoji.Unbanned} Successfully unbanned");
+        readonly public static Regex id_rx = new("[0-9]{17,}");
     }
 }

--- a/Constants/RegexConstants.cs
+++ b/Constants/RegexConstants.cs
@@ -9,10 +9,10 @@
         readonly public static Regex bold_rx = new("\\*\\*(.*?)\\*\\*");
         readonly public static Regex discord_link_rx = new(@".*discord(?:app)?.com\/channels\/((?:@)?[a-z0-9]*)\/([0-9]*)(?:\/)?([0-9]*)");
         readonly public static Regex channel_rx = new("<#([0-9]+)>");
-        readonly public static Regex user_rx = new("<@([0-9]+)>");
+        readonly public static Regex user_rx = new("<@!?([0-9]+)>");
         readonly public static Regex role_rx = new("<@&([0-9]+)>");
-        readonly public static Regex warn_msg_rx = new($"{Program.cfgjson.Emoji.Warning} <@!?[0-9]+> was warned");
-        readonly public static Regex auto_warn_msg_rx = new($"{Program.cfgjson.Emoji.Denied} <@!?[0-9]+> was automatically warned");
+        readonly public static Regex warn_msg_rx = new($"{Program.cfgjson.Emoji.Warning} <@!?[0-9]+> was warned: \\*\\*(.+)\\*\\*");
+        readonly public static Regex auto_warn_msg_rx = new($"{Program.cfgjson.Emoji.Denied} <@!?[0-9]+> was automatically warned: \\*\\*(.+)\\*\\*");
         readonly public static Regex mute_msg_rx = new($"{Program.cfgjson.Emoji.Muted} <@!?[0-9]+> has been muted");
         readonly public static Regex unmute_msg_rx = new($"{Program.cfgjson.Emoji.Information} Successfully unmuted");
         readonly public static Regex ban_msg_rx = new($"{Program.cfgjson.Emoji.Banned} <@!?[0-9]+> has been banned");

--- a/Events/ReactionEvent.cs
+++ b/Events/ReactionEvent.cs
@@ -25,21 +25,75 @@ namespace Cliptok.Events
             {
                 await targetMessage.DeleteReactionAsync(e.Emoji, e.User);
                 var emoji = e.Emoji.Id != 0 ? $"[{e.Emoji.Name}](<{e.Emoji.Url}>)" : e.Emoji.ToString();
-                await LogChannelHelper.LogMessageAsync("reactions", $"<:WindowsRecycleBin:824380487920910348> Removed reaction {emoji} from {e.Message.JumpLink} by {e.User.Mention}");
+                await LogChannelHelper.LogMessageAsync("reactions", $"<:WindowsRecycleBin:824380487920910348> Removed reaction {emoji} from {targetMessage.JumpLink} by {e.User.Mention}");
                 return;
             }
 
             // Remove self-heartosofts
-
-            if (e.Emoji.Id != cfgjson.HeartosoftId)
-                return;
-
-            // Avoid starboard race conditions
-            await Task.Delay(1000);
-
-            if (targetMessage.Author.Id == e.User.Id)
+            if (e.Emoji.Id == cfgjson.HeartosoftId)
             {
-                await targetMessage.DeleteReactionAsync(e.Emoji, e.User);
+                // Avoid starboard race conditions
+                await Task.Delay(1000);
+
+                if (targetMessage.Author.Id == e.User.Id)
+                {
+                    await targetMessage.DeleteReactionAsync(e.Emoji, e.User);
+                }
+            }
+
+            // Reaction to undo warnings in log channels
+            
+            if (e.User.Id == discord.CurrentUser.Id)
+                return;
+            
+            if (e.Channel.Id != cfgjson.InvestigationsChannelId && e.Channel.Id != cfgjson.LogChannels["mod"].ChannelId)
+                return;
+            
+            var member = await e.Guild.GetMemberAsync(e.User.Id);
+            if (await GetPermLevelAsync(member) < ServerPermLevel.TrialModerator)
+                return;
+            
+            var recycleBinEmoji = DiscordEmoji.FromGuildEmote(discord, Convert.ToUInt64(id_rx.Match(cfgjson.Emoji.Deleted).ToString()));
+            
+            if (e.Channel.Id == cfgjson.LogChannels["mod"].ChannelId)
+            {
+                var warningId = targetMessage.Embeds[0].Fields?.First(x => x.Name == "Warning ID").Value;
+                if (warningId is null) // probably reacted to non-warning msg, ignore
+                    return;
+                
+                var targetUserId = Convert.ToUInt64(user_rx.Match(targetMessage.Content).Groups[1].ToString());
+                var warning = WarningHelpers.GetWarning(targetUserId, Convert.ToUInt32(warningId));
+                
+                if ((await GetPermLevelAsync(member)) == ServerPermLevel.TrialModerator && warning.ModUserId != e.User.Id && warning.ModUserId != discord.CurrentUser.Id)
+                    return;
+                
+                if (warning is null)
+                {
+                    await targetMessage.DeleteReactionsEmojiAsync(recycleBinEmoji);
+                    return;
+                }
+
+                bool success = await WarningHelpers.DelWarningAsync(warning, targetUserId);
+                if (success)
+                {
+                    await LogChannelHelper.LogMessageAsync("mod",
+                        new DiscordMessageBuilder()
+                            .WithContent($"{Program.cfgjson.Emoji.Deleted} Warning deleted:" +
+                                         $"`{StringHelpers.Pad(warning.WarningId)}` (belonging to <@{targetUserId}>, deleted by {e.User.Mention})")
+                            .AddEmbed(await WarningHelpers.FancyWarnEmbedAsync(warning, true, 0xf03916, true, targetUserId))
+                            .WithAllowedMentions(Mentions.None)
+                    );
+                    
+                    await targetMessage.DeleteReactionsEmojiAsync(recycleBinEmoji);
+                }
+                else
+                {
+                    await targetMessage.CreateReactionAsync(DiscordEmoji.FromName(discord, ":x:"));
+                }
+            }
+            else
+            {
+                // TODO #investigations
             }
         }
     }

--- a/Helpers/InvestigationsHelpers.cs
+++ b/Helpers/InvestigationsHelpers.cs
@@ -57,7 +57,7 @@
                 await logMsg.CreateReactionAsync(emoji);
                 Task.Run(async () =>
                 {
-                    await Task.Delay(120000);
+                    await Task.Delay(TimeSpan.FromMinutes(Program.cfgjson.WarningLogReactionTimeMinutes));
                     await logMsg.DeleteOwnReactionAsync(emoji);
                 });
             }

--- a/Helpers/InvestigationsHelpers.cs
+++ b/Helpers/InvestigationsHelpers.cs
@@ -44,10 +44,23 @@
                 else
                     content = $"{Program.cfgjson.Emoji.Denied} Deleted infringing message by {infringingMessage.Author.Mention} in {infringingMessage.Channel.Mention}:";
 
+            DiscordMessage logMsg;
             if (channelOverride == default)
-                await LogChannelHelper.LogMessageAsync(logChannelKey, content, embed);
+                logMsg = await LogChannelHelper.LogMessageAsync(logChannelKey, content, embed);
             else
-                await channelOverride.SendMessageAsync(new DiscordMessageBuilder().WithContent(content).AddEmbed(embed).WithAllowedMentions(Mentions.None));
+                logMsg = await channelOverride.SendMessageAsync(new DiscordMessageBuilder().WithContent(content).AddEmbed(embed).WithAllowedMentions(Mentions.None));
+            
+            // Add reaction to log message to be used to delete
+            if (logChannelKey == "investigations")
+            {
+                var emoji = DiscordEmoji.FromGuildEmote(Program.discord, Convert.ToUInt64(Constants.RegexConstants.id_rx.Match(Program.cfgjson.Emoji.Deleted).ToString()));
+                await logMsg.CreateReactionAsync(emoji);
+                Task.Run(async () =>
+                {
+                    await Task.Delay(120000);
+                    await logMsg.DeleteOwnReactionAsync(emoji);
+                });
+            }
         }
 
     }

--- a/Helpers/WarningHelpers.cs
+++ b/Helpers/WarningHelpers.cs
@@ -258,7 +258,7 @@
                 await logMsg.CreateReactionAsync(emoji);
                 Task.Run(async () =>
                 {
-                    await Task.Delay(120000);
+                    await Task.Delay(TimeSpan.FromMinutes(Program.cfgjson.WarningLogReactionTimeMinutes));
                     await logMsg.DeleteOwnReactionAsync(emoji);
                 });
             }

--- a/Helpers/WarningHelpers.cs
+++ b/Helpers/WarningHelpers.cs
@@ -246,12 +246,26 @@
                 Program.db.HashSet("automaticWarnings", warningId, JsonConvert.SerializeObject(warning));
             }
 
-            LogChannelHelper.LogMessageAsync("mod",
+            var logMsg = await LogChannelHelper.LogMessageAsync("mod",
                 new DiscordMessageBuilder()
                     .WithContent($"{Program.cfgjson.Emoji.Warning} New warning for {targetUser.Mention}!")
                     .AddEmbed(await FancyWarnEmbedAsync(warning, true, 0xFEC13D, false, targetUser.Id))
                     .WithAllowedMentions(Mentions.None)
             );
+            try
+            {
+                var emoji = DiscordEmoji.FromGuildEmote(Program.discord, Convert.ToUInt64(Constants.RegexConstants.id_rx.Match(Program.cfgjson.Emoji.Deleted).ToString()));
+                await logMsg.CreateReactionAsync(emoji);
+                Task.Run(async () =>
+                {
+                    await Task.Delay(120000);
+                    await logMsg.DeleteOwnReactionAsync(emoji);
+                });
+            }
+            catch
+            {
+                // Don't really care if this fails
+            }
 
             // automute handling
             var warningsOutput = (await Program.db.HashGetAllAsync(targetUser.Id.ToString())).ToDictionary(

--- a/Structs.cs
+++ b/Structs.cs
@@ -348,6 +348,9 @@
 
         [JsonProperty("duplicateMessageSeconds")]
         public int DuplicateMessageSeconds { get; private set; } = 0;
+        
+        [JsonProperty("warningLogReactionTimeMinutes")]
+        public int WarningLogReactionTimeMinutes { get; private set; }
     }
 
     public enum Level { Information, Warning, Error, Debug, Verbose }

--- a/config.json
+++ b/config.json
@@ -359,5 +359,6 @@
   "githubWorkflowSucessString": "[lists:main] 1 new commit",
   "botCommandsChannel": 740272437719072808,
   "duplicateMessageThreshold": 4,
-  "duplicateMessageSeconds": 10
+  "duplicateMessageSeconds": 10,
+  "warningLogReactionTimeMinutes": 5
 }


### PR DESCRIPTION
Closes #282 

Adds the `!revoke` command (alias `!undo`) that can be used to delete a warning by sending the command as a reply to any public warning message.

Also adds temporary CliptokRecycleBin reactions to warning logs in the `mod` and `investigations` log channels that will delete the respective warning when clicked. These are removed automatically after 2 minutes. In `investigations`, the bot responds with a CliptokSuccess reaction to indicate success (in `mod` it's assumed you will just see the deletion log). On error, it responds with CliptokError instead (in both channels). Reactions on invalid messages, or on messages for which the warnings have already been deleted, are just ignored or deleted.

This PR also updates a few regular expressions a bit, but those changes shouldn't break anything