### PR TITLE
Upgrade DSharpPlus to 5.0.0-nightly-02510

### DIFF
--- a/Cliptok.csproj
+++ b/Cliptok.csproj
@@ -15,13 +15,13 @@
 
 	<ItemGroup>
 		<PackageReference Include="Abyssal.HumanDateParser" Version="2.0.0-20191113.1" />
-		<PackageReference Include="DSharpPlus" Version="5.0.0-nightly-02488" />
-		<PackageReference Include="DSharpPlus.Commands" Version="5.0.0-nightly-02488" />
+		<PackageReference Include="DSharpPlus" Version="5.0.0-nightly-02510" />
+		<PackageReference Include="DSharpPlus.Commands" Version="5.0.0-nightly-02510" />
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.2" />
-		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.3" />
-		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.3" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
-		<PackageReference Include="Microsoft.Extensions.Options" Version="9.0.3" />
+		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.4" />
+		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.4" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />
+		<PackageReference Include="Microsoft.Extensions.Options" Version="9.0.4" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="Serilog" Version="4.2.0" />
 		<PackageReference Include="Serilog.Expressions" Version="5.0.0" />

--- a/Commands/AnnouncementCmds.cs
+++ b/Commands/AnnouncementCmds.cs
@@ -404,7 +404,7 @@ namespace Cliptok.Commands
             
             EditAnnounceCache[ctx.User.Id] = (Convert.ToUInt64(messageId), role1Name, role2Name);
 
-            await ctx.RespondWithModalAsync(new DiscordInteractionResponseBuilder().WithTitle("Edit Announcement").WithCustomId("editannounce-modal-callback").AddComponents(new DiscordTextInputComponent("New announcement text. Do not include roles!", "editannounce-modal-new-text", value: msg.Content, style: DiscordTextInputStyle.Paragraph)));
+            await ctx.RespondWithModalAsync(new DiscordInteractionResponseBuilder().WithTitle("Edit Announcement").WithCustomId("editannounce-modal-callback").AddTextInputComponent(new DiscordTextInputComponent("New announcement text. Do not include roles!", "editannounce-modal-new-text", value: msg.Content, style: DiscordTextInputStyle.Paragraph)));
         }
 
         [Command("announcetextcmd")]

--- a/Commands/ClearCmds.cs
+++ b/Commands/ClearCmds.cs
@@ -267,7 +267,7 @@
             if (messagesToClear.Count >= 50)
             {
                 DiscordButtonComponent confirmButton = new(DiscordButtonStyle.Danger, "clear-confirm-callback", "Delete Messages");
-                DiscordMessage confirmationMessage = await ctx.FollowupAsync(new DiscordFollowupMessageBuilder().WithContent($"{Program.cfgjson.Emoji.Muted} You're about to delete {messagesToClear.Count} messages. Are you sure?").AddComponents(confirmButton).AsEphemeral(true));
+                DiscordMessage confirmationMessage = await ctx.FollowupAsync(new DiscordFollowupMessageBuilder().WithContent($"{Program.cfgjson.Emoji.Muted} You're about to delete {messagesToClear.Count} messages. Are you sure?").AddActionRowComponent(confirmButton).AsEphemeral(true));
 
                 MessagesToClear.Add(confirmationMessage.Id, messagesToClear);
             }

--- a/Commands/DebugCmds.cs
+++ b/Commands/DebugCmds.cs
@@ -483,7 +483,7 @@ namespace Cliptok.Commands
                             $"{Program.cfgjson.Emoji.ShieldHelp} Just to confirm, you want to add the following override for {user.Mention} to {channel.Mention}?\n" +
                             $"**Allowed:** {allowedPermsStr}\n" +
                             $"**Denied:** {deniedPermsStr}\n")
-                        .AddComponents([confirmButton, cancelButton]));
+                        .AddActionRowComponent([confirmButton, cancelButton]));
                     var confirmationMessage = await ctx.GetResponseAsync();
 
                     OverridesPendingAddition.Add(confirmationMessage.Id, new PendingUserOverride

--- a/Commands/InsidersInteractions.cs
+++ b/Commands/InsidersInteractions.cs
@@ -1,4 +1,4 @@
-namespace Cliptok.Commands.InteractionCommands
+namespace Cliptok.Commands
 {
     public class InsidersInteractions
     {
@@ -12,7 +12,7 @@ namespace Cliptok.Commands.InteractionCommands
                 return;
             }
 
-            DiscordComponent[] buttons =
+            DiscordButtonComponent[] buttons =
             [
                 new DiscordButtonComponent(DiscordButtonStyle.Primary, "insiders-info-roles-menu-callback", "Choose your Insider roles"),
                 new DiscordButtonComponent(DiscordButtonStyle.Secondary, "insiders-info-chat-btn-callback", "I just want to chat for now")
@@ -31,7 +31,7 @@ namespace Cliptok.Commands.InteractionCommands
 
             var builder = new DiscordInteractionResponseBuilder()
                 .WithContent($"{Program.cfgjson.Emoji.Insider} Choose your Insider roles here! Or, you can choose to chat in {insidersChannelMention} without being notified about new builds.")
-                .AddComponents(buttons);
+                .AddActionRowComponent(buttons);
 
             await ctx.RespondAsync(builder);
         }

--- a/Events/InteractionEvents.cs
+++ b/Events/InteractionEvents.cs
@@ -119,7 +119,7 @@ namespace Cliptok.Events
 
                         var mergeConfirmResponse = new DiscordMessageBuilder()
                             .WithContent($"{cfgjson.Emoji.Warning} **Caution:** This user already has an override for <#{channelId}>! Do you want to merge the permissions? Here are their **current** permissions:\n**Allowed:** {currentAllowedPerms}\n**Denied:** {currentDeniedPerms}")
-                            .AddComponents(new DiscordButtonComponent(DiscordButtonStyle.Danger, "debug-overrides-add-merge-confirm-callback", "Merge"), new DiscordButtonComponent(DiscordButtonStyle.Primary, "debug-overrides-add-cancel-callback", "Cancel"));
+                            .AddActionRowComponent(new DiscordButtonComponent(DiscordButtonStyle.Danger, "debug-overrides-add-merge-confirm-callback", "Merge"), new DiscordButtonComponent(DiscordButtonStyle.Primary, "debug-overrides-add-cancel-callback", "Cancel"));
 
                         await e.Message.ModifyAsync(mergeConfirmResponse);
                         return;
@@ -256,7 +256,7 @@ namespace Cliptok.Events
 
                 var builder = new DiscordFollowupMessageBuilder()
                     .WithContent($"{cfgjson.Emoji.Insider} Use the menu below to toggle your Insider roles!")
-                    .AddComponents(menu)
+                    .AddActionRowComponent(menu)
                     .AsEphemeral(true);
 
                 await e.Interaction.CreateFollowupMessageAsync(builder);
@@ -359,7 +359,7 @@ namespace Cliptok.Events
                     // Ask them if they'd like to remove it
                     var confirmResponse = new DiscordFollowupMessageBuilder()
                         .WithContent($"{cfgjson.Emoji.Warning} You already have the {insiderChatRole.Mention} role! Would you like to remove it?")
-                        .AddComponents(new DiscordButtonComponent(DiscordButtonStyle.Danger, "insiders-info-chat-btn-remove-confirm-callback", "Remove"));
+                        .AddActionRowComponent(new DiscordButtonComponent(DiscordButtonStyle.Danger, "insiders-info-chat-btn-remove-confirm-callback", "Remove"));
 
                     await e.Interaction.CreateFollowupMessageAsync(confirmResponse);
                 }
@@ -368,7 +368,7 @@ namespace Cliptok.Events
                     // Member does not have the role; show a confirmation message with a button that will give it to them
                     await e.Interaction.CreateFollowupMessageAsync(new DiscordFollowupMessageBuilder()
                         .WithContent($"{cfgjson.Emoji.Warning} Please note that <#{cfgjson.InsidersChannel}> is **not for tech support**! If you need tech support, please ask in the appropriate channels instead. Press the button to acknowledge this and get the {insiderChatRole.Mention} role.")
-                        .AddComponents(new DiscordButtonComponent(DiscordButtonStyle.Secondary, "insiders-info-chat-btn-confirm-callback", "I understand")));
+                        .AddActionRowComponent(new DiscordButtonComponent(DiscordButtonStyle.Secondary, "insiders-info-chat-btn-confirm-callback", "I understand")));
                 }
             }
             else if (e.Id == "insiders-info-chat-btn-confirm-callback")

--- a/Events/MessageEvent.cs
+++ b/Events/MessageEvent.cs
@@ -903,7 +903,7 @@ namespace Cliptok.Events
                             DiscordMessage msg;
                             if (!wasAutoModBlock)
                             {
-                                messageBuilder.AddComponents(new DiscordButtonComponent(DiscordButtonStyle.Secondary, "line-limit-deleted-message-callback", "View message content", false, null));
+                                messageBuilder.AddActionRowComponent(new DiscordButtonComponent(DiscordButtonStyle.Secondary, "line-limit-deleted-message-callback", "View message content", false, null));
                                 msg = await channel.SendMessageAsync(messageBuilder);
                                 await Program.db.HashSetAsync("deletedMessageReferences", msg.Id, message.Content);
                             }
@@ -923,7 +923,7 @@ namespace Cliptok.Events
                             DiscordMessage msg;
                             if (!wasAutoModBlock)
                             {
-                                messageBuilder.AddComponents(new DiscordButtonComponent(DiscordButtonStyle.Secondary, "line-limit-deleted-message-callback", "View message content", false, null));
+                                messageBuilder.AddActionRowComponent(new DiscordButtonComponent(DiscordButtonStyle.Secondary, "line-limit-deleted-message-callback", "View message content", false, null));
                                 msg = await channel.SendMessageAsync(messageBuilder);
                                 await Program.db.HashSetAsync("deletedMessageReferences", msg.Id, message.Content);
                             }

--- a/Helpers/InteractionHelpers.cs
+++ b/Helpers/InteractionHelpers.cs
@@ -7,13 +7,12 @@
             await ctx.DeferResponseAsync();
         }
 
-        public static async Task RespondAsync(this CommandContext ctx, string text = null, DiscordEmbed embed = null, bool ephemeral = false, bool mentions = true, params DiscordComponent[] components)
+        public static async Task RespondAsync(this CommandContext ctx, string text = null, DiscordEmbed embed = null, bool ephemeral = false, bool mentions = true)
         {
             DiscordInteractionResponseBuilder response = new();
 
             if (text is not null) response.WithContent(text);
             if (embed is not null) response.AddEmbed(embed);
-            if (components.Length != 0) response.AddComponents(components);
 
             response.AsEphemeral(ephemeral);
             response.AddMentions(mentions ? Mentions.All : Mentions.None);
@@ -21,18 +20,17 @@
             await ctx.RespondAsync(response);
         }
 
-        public static async Task EditAsync(this CommandContext ctx, string text = null, DiscordEmbed embed = null, params DiscordComponent[] components)
+        public static async Task EditAsync(this CommandContext ctx, string text = null, DiscordEmbed embed = null)
         {
             DiscordWebhookBuilder response = new();
 
             if (text is not null) response.WithContent(text);
             if (embed is not null) response.AddEmbed(embed);
-            if (components.Length != 0) response.AddComponents(components);
 
             await ctx.EditResponseAsync(response);
         }
 
-        public static async Task FollowAsync(this CommandContext ctx, string text = null, DiscordEmbed embed = null, bool ephemeral = false, params DiscordComponent[] components)
+        public static async Task FollowAsync(this CommandContext ctx, string text = null, DiscordEmbed embed = null, bool ephemeral = false)
         {
             DiscordFollowupMessageBuilder response = new();
 
@@ -40,7 +38,6 @@
 
             if (text is not null) response.WithContent(text);
             if (embed is not null) response.AddEmbed(embed);
-            if (components.Length != 0) response.AddComponents(components);
 
             response.AsEphemeral(ephemeral);
 

--- a/Program.cs
+++ b/Program.cs
@@ -3,6 +3,7 @@ using DSharpPlus.Extensions;
 using DSharpPlus.Net.Gateway;
 using Serilog.Sinks.Grafana.Loki;
 using System.Reflection;
+using Serilog.Events;
 
 namespace Cliptok
 {
@@ -92,7 +93,8 @@ namespace Cliptok
                     lc.Filter.ByExcluding("EventId.Id = 1001")
                 .WriteTo.DiscordSink(restrictedToMinimumLevel: Serilog.Events.LogEventLevel.Information, outputTemplate: logFormat)
                 )
-                .WriteTo.Console(outputTemplate: logFormat, theme: AnsiConsoleTheme.Literate);
+                .WriteTo.Console(outputTemplate: logFormat, theme: AnsiConsoleTheme.Literate)
+                .MinimumLevel.Override("System.Net.Http", LogEventLevel.Error);
 
             string token;
             var json = "";


### PR DESCRIPTION
PRing because I want a second set of eyes on this, especially with the voice changes :P

But also, important! This PR removes the `params DiscordComponent[] components` parameters from the methods in InteractionHelpers. I don't THINK these are used anywhere & they are not compatible with the changes in this DSharpPlus upgrade (there's no more `IDiscordMessageBuilder.AddComponents()` for example, need to be more specific with `.AddTextInputComponent()`, `.AddActionRowComponent`, etc.). Wasn't sure how best to change those helpers to use the more-specific methods, but since they don't seem to be used, I didn't want to delay this just for that

Also, discussed on Discord (https://discord.com/channels/150662382874525696/793285213823172628/1374131151177912360) but to have it noted here too—some part of this upgrade introduces many HTTP logs that look like they should be logged at the Debug level, but that are logged at Information instead. This causes issues with sending logs to Discord, so logs from System.Net.Http below Error are suppressed