### PR TITLE
Autowarn for CTS pings outside of tech support channels

### DIFF
--- a/Events/MessageEvent.cs
+++ b/Events/MessageEvent.cs
@@ -1183,7 +1183,7 @@ namespace Cliptok.Events
                         else // also false when set does not exist
                         {
                             await Program.redis.SetAddAsync("ctsPingPardons", message.Author.Id);
-                            await channel.SendMessageAsync($"{Program.cfgjson.Emoji.Information} {message.Author.Mention}, you mentioned Community Tech Support outside of a tech support channel.\n"
+                            await channel.SendMessageAsync($"{Program.cfgjson.Emoji.Information} {message.Author.Mention}, you mentioned the tech support role outside of a tech support channel.\n"
                                 + $"Please keep requests for tech support inside {techSupportChannelsText} to avoid further punishment.");
                         }
                 }


### PR DESCRIPTION
Closes #152 

Automatically warns users for pinging `@Community Tech Support` outside of #tech-support, #tech-support-forum, or their threads. Doesn't delete the infringing message like most autowarns, because I don't want to leave CTS members with ghost pings

The first ping is pardoned, like the mass emoji or line limit filters—subsequent pings are warned for

<img width="1051" height="189" alt="image" src="https://github.com/user-attachments/assets/cc5c9f70-2eb3-4048-9257-0ba8e4181cd6" />
(slight change from the screenshot, the one instance of "technical support channel" was changed to "tech support channel" but otherwise it's the same)