### PR TITLE
Automatically dehoist & undehoist on mute & unmute

### DIFF
--- a/Helpers/MuteHelpers.cs
+++ b/Helpers/MuteHelpers.cs
@@ -315,6 +315,14 @@
 
             await Program.redis.HashSetAsync("mutes", naughtyUser.Id, JsonConvert.SerializeObject(newMute));
             MostRecentMute = newMute;
+            
+            // attempt to dehoist member if they aren't already dehoisted
+            if (naughtyMember.DisplayName[0] != DehoistHelpers.dehoistCharacter)
+                await naughtyMember.ModifyAsync(x =>
+                {
+                    x.Nickname = DehoistHelpers.DehoistName(naughtyMember.DisplayName);
+                    x.AuditLogReason = "[Automatic dehoist on mute]";
+                });
 
             return output;
         }
@@ -455,6 +463,20 @@
             // Even if the bot failed to remove the role, it reported that failure to a log channel and thus the mute
             //  can be safely removed internally.
             await Program.redis.HashDeleteAsync("mutes", targetUser.Id);
+            
+            // attempt to undehoist member if they should not otherwise be hoisted
+            if (member.Nickname is not null && member.Nickname[0] == DehoistHelpers.dehoistCharacter && !Program.cfgjson.AutoDehoistCharacters.Contains(member.Nickname[1]) && !Program.cfgjson.SecondaryAutoDehoistCharacters.Contains(member.Nickname[1]))
+            {
+                var undehoistedNickname = member.Nickname[1..];
+                if (undehoistedNickname == member.GlobalName || (member.GlobalName is null && undehoistedNickname == member.Username))
+                    undehoistedNickname = null;
+                
+                await member.ModifyAsync(x =>
+                {
+                    x.Nickname = undehoistedNickname;
+                    x.AuditLogReason = "[Automatic undehoist on unmute]";
+                });
+            }
 
             return true;
         }


### PR DESCRIPTION
Closes #90 

Automatically dehoists members when they are muted, and undehoists them when they are unmuted (only if they would not be immediately auto-dehoisted again / if their name does not start with a hoisting character after the dehoist character). When undehoisting, the member's nickname is just cleared if it is the same as their global display name (or username if their display name is not set).

Logged to the Audit Log with reasons `[Automatic dehoist on mute]` and `[Automatic undehoist on unmute]`.