### PR TITLE
Pardon first image scam filter match, adjust warning reason

### DIFF
--- a/Events/MessageEvent.cs
+++ b/Events/MessageEvent.cs
@@ -781,9 +781,34 @@ namespace Cliptok.Events
                 else
                     Program.discord.Logger.LogDebug("Message {messageId} in {channelId} by user {userId} triggered scam image URL filter", message.Id, channel.Id, message.Author.Id);
 
-                await DeleteAndWarnAsync(message, "Attempted scam message", client, wasAutoModBlock: wasAutoModBlock, messageContentOverride: messageContentOverride);
+                await DiscordHelpers.ThreadChannelAwareDeleteMessageAsync(message);
 
-                return true;
+                string reason = "Possible scam message";
+
+                if (!Program.redis.SetContains("scamMessagePardoned", message.Author.Id.ToString()))
+                {
+                    await Program.redis.SetAddAsync("scamMessagePardoned", message.Author.Id.ToString());
+                    string output = $"{Program.cfgjson.Emoji.Information} {message.Author.Mention}, your message was deleted because it matched patterns of common scam messages." +
+                            $"\nWhen sending multiple images, please either send them separately or include some text in your message to avoid triggering filters.";
+                    DiscordMessage msg = await channel.SendMessageAsync(output);
+                    await InvestigationsHelpers.SendInfringingMessaageAsync("investigations", message, reason, DiscordHelpers.MessageLink(msg), messageContentOverride: messageContentOverride);
+                    await InvestigationsHelpers.SendInfringingMessaageAsync("mod", message, reason, DiscordHelpers.MessageLink(msg), messageContentOverride: messageContentOverride);
+                    return true;
+                }
+                else
+                {
+                    string output = $"{Program.cfgjson.Emoji.Denied} {message.Author.Mention} was automatically warned: **{reason.Replace("`", "\\`").Replace("*", "\\*")}**\n"
+                        + $"When sending multiple images, please either send them separately or include some text in your message to avoid triggering filters.";
+                    DiscordMessageBuilder messageBuilder = new();
+                    messageBuilder.WithContent(output);
+                    DiscordMessage msg = await channel.SendMessageAsync(output);
+
+                    await InvestigationsHelpers.SendInfringingMessaageAsync("mod", message, reason, null, messageContentOverride: messageContentOverride);
+                    var warning = await WarningHelpers.GiveWarningAsync(message.Author, client.CurrentUser, reason, contextMessage: msg, channel, " automatically ");
+                    await InvestigationsHelpers.SendInfringingMessaageAsync("investigations", message, reason, warning.ContextLink, messageContentOverride: messageContentOverride);
+
+                    return true;
+                }
             }
             return false;
         }


### PR DESCRIPTION
Closes #354. Pardons the first scam image url filter match, works like mass emoji / too many lines / mod action reply. Also changes warning reason from "Attempted scam message" to "Possible scam message"