### PR TITLE
Revert "warnings: Remove ContextMessageReference when context message is deleted"

### DIFF
--- a/Events/MessageEvent.cs
+++ b/Events/MessageEvent.cs
@@ -123,21 +123,6 @@ namespace Cliptok.Events
                     await Program.redis.HashDeleteAsync("compromisedAccountBans", ban.Name);
             }
 
-            // If this was a public warning message, remove the message from the warning record to avoid errors later if the warning is edited/deleted
-            if (e.Message.Author.Id == client.CurrentUser.Id && (Constants.RegexConstants.auto_warn_msg_rx.IsMatch(e.Message.Content) || Constants.RegexConstants.warn_msg_rx.IsMatch(e.Message.Content)))
-            {
-                var warnedUserId = Convert.ToUInt64(Constants.RegexConstants.user_rx.Match(e.Message.Content).Groups[1].Value);
-                var userWarnings = await Program.redis.HashGetAllAsync(warnedUserId.ToString());
-                var thisWarning = userWarnings.Select(x => JsonConvert.DeserializeObject<UserWarning>(x.Value))
-                    .FirstOrDefault(x => x.ContextMessageReference?.MessageId == e.Message.Id);
-
-                if (thisWarning != default)
-                {
-                    thisWarning.ContextMessageReference = null;
-                    await Program.redis.HashSetAsync(warnedUserId.ToString(), thisWarning.WarningId, JsonConvert.SerializeObject(thisWarning));
-                }
-            }
-
             if (Program.cfgjson.EnablePersistentDb)
             {
                 using (var dbContext = new CliptokDbContext())
@@ -182,21 +167,6 @@ namespace Cliptok.Events
                 {
                     if (JsonConvert.DeserializeObject<MemberPunishment>(ban.Value).ContextMessageReference.MessageId == message.Id)
                         await Program.redis.HashDeleteAsync("compromisedAccountBans", ban.Name);
-                }
-
-                // If this was a public warning message, remove the message from the warning record to avoid errors later if the warning is edited/deleted
-                if (message.Author.Id == client.CurrentUser.Id && (Constants.RegexConstants.auto_warn_msg_rx.IsMatch(message.Content) || Constants.RegexConstants.warn_msg_rx.IsMatch(message.Content)))
-                {
-                    var warnedUserId = Convert.ToUInt64(Constants.RegexConstants.user_rx.Match(message.Content).Groups[1].Value);
-                    var userWarnings = await Program.redis.HashGetAllAsync(warnedUserId.ToString());
-                    var thisWarning = userWarnings.Select(x => JsonConvert.DeserializeObject<UserWarning>(x.Value))
-                        .FirstOrDefault(x => x.ContextMessageReference?.MessageId == message.Id);
-
-                    if (thisWarning != default)
-                    {
-                        thisWarning.ContextMessageReference = null;
-                        await Program.redis.HashSetAsync(warnedUserId.ToString(), thisWarning.WarningId, JsonConvert.SerializeObject(thisWarning));
-                    }
                 }
             }
 


### PR DESCRIPTION
Reverts Erisa/Cliptok#360

Reverting due to NREs

```cs
[2026-06-21 09:14:52 +00:00] [Error] Event handler exception for event "DSharpPlus.EventArgs.MessageDeletedEventArgs" thrown from "System.Threading.Tasks.Task <CanonicalizeSimpleDelegateHandler>b__0(DSharpPlus.DiscordClient, DSharpPlus.EventArgs.DiscordEventArgs, System.IServiceProvider)" (defined in "DSharpPlus.EventHandlerCollection+<>c__DisplayClass8_0").
System.NullReferenceException: Object reference not set to an instance of an object.
   at Cliptok.Events.MessageEvent.MessageDeleted(DiscordClient client, MessageDeletedEventArgs e) in /app/Events/MessageEvent.cs:line 120
   at DSharpPlus.Clients.DefaultEventDispatcher.<>c__DisplayClass9_1`1.<<DispatchAsync>b__1>d.MoveNext()
```