### PR TITLE
Upgrade DSharpPlus to 5.0.0-nightly-02594

### DIFF
--- a/Cliptok.csproj
+++ b/Cliptok.csproj
@@ -16,8 +16,8 @@
 	<ItemGroup>
 		<PackageReference Include="Abyssal.HumanDateParser" Version="2.0.0-20191113.1" />
 		<PackageReference Include="DiffPlex" Version="1.9.0" />
-		<PackageReference Include="DSharpPlus" Version="5.0.0-nightly-02587" />
-		<PackageReference Include="DSharpPlus.Commands" Version="5.0.0-nightly-02587" />
+		<PackageReference Include="DSharpPlus" Version="5.0.0-nightly-02594" />
+		<PackageReference Include="DSharpPlus.Commands" Version="5.0.0-nightly-02594" />
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.8" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Events/ReadyEvent.cs
+++ b/Events/ReadyEvent.cs
@@ -158,27 +158,7 @@ namespace Cliptok.Events
                 $"{commitMessage}\n" +
                 $"```");
 
-            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("UPTIME_KUMA_PUSH_URL")))
-            {
-                HttpResponseMessage response;
-                try
-                {
-                    response = await Program.httpClient.GetAsync(Environment.GetEnvironmentVariable("UPTIME_KUMA_PUSH_URL"));
-                }
-                catch (Exception ex)
-                {
-                    discord.Logger.LogError(ex, "Uptime Kuma push failed during startup!");
-                    return;
-                }
-                if (response.StatusCode == HttpStatusCode.OK)
-                {
-                    discord.Logger.LogDebug("Heartbeat ping succeeded.");
-                }
-                else
-                {
-                    discord.Logger.LogError("Heartbeat ping sent: {status} {content}", (int)response.StatusCode, await response.Content.ReadAsStringAsync());
-                }
-            }
+            await Tasks.HeartbeatTasks.HeartbeatAsync();
 
             try
             {

--- a/Program.cs
+++ b/Program.cs
@@ -1,6 +1,5 @@
 using DSharpPlus.Commands.Processors.TextCommands.Parsing;
 using DSharpPlus.Extensions;
-using DSharpPlus.Net.Gateway;
 using Serilog.Events;
 using Serilog.Sinks.Grafana.Loki;
 using System.Reflection;
@@ -14,30 +13,6 @@ namespace Cliptok
 
         [JsonProperty("key")]
         public string Key { get; set; }
-    }
-
-    class GatewayController : IGatewayController
-    {
-        public async Task HeartbeatedAsync(IGatewayClient client)
-        {
-            HeartbeatEvent.OnHeartbeat(client);
-        }
-
-        public async Task ZombiedAsync(IGatewayClient client)
-        {
-            Program.discord.Logger.LogCritical("The gateway connection has zombied, and the bot is being restarted to reconnect reliably.");
-            Environment.Exit(1);
-        }
-
-        public async Task ReconnectRequestedAsync(IGatewayClient _) { }
-        public async Task ReconnectFailedAsync(IGatewayClient _)
-        {
-            Program.discord.Logger.LogCritical("The gateway connection has irrecoverably failed, and the bot is being restarted to reconnect reliably.");
-            Environment.Exit(1);
-        }
-        public async Task SessionInvalidatedAsync(IGatewayClient _) { }
-        public async Task ResumeAttemptedAsync(IGatewayClient _) { }
-
     }
 
     class Program
@@ -212,11 +187,6 @@ namespace Cliptok
                 logging.AddSerilog();
             });
 
-            discordBuilder.ConfigureServices(services =>
-            {
-                services.Replace<IGatewayController, GatewayController>();
-            });
-
             discordBuilder.UseCommands((_, builder) =>
             {
                 builder.CommandErrored += ErrorEvents.CommandErrored;
@@ -312,6 +282,7 @@ namespace Cliptok
                 {
                     List<Task<bool>> taskList =
                     [
+                        Tasks.HeartbeatTasks.HeartbeatAsync(),
                         Tasks.PunishmentTasks.CheckMutesAsync(),
                         Tasks.PunishmentTasks.CheckBansAsync(),
                         Tasks.PunishmentTasks.CleanUpPunishmentMessagesAsync(),

--- a/Program.cs
+++ b/Program.cs
@@ -282,7 +282,6 @@ namespace Cliptok
                 {
                     List<Task<bool>> taskList =
                     [
-                        Tasks.HeartbeatTasks.HeartbeatAsync(),
                         Tasks.PunishmentTasks.CheckMutesAsync(),
                         Tasks.PunishmentTasks.CheckBansAsync(),
                         Tasks.PunishmentTasks.CleanUpPunishmentMessagesAsync(),
@@ -308,6 +307,13 @@ namespace Cliptok
                 }
 
                 loopCount += 1;
+
+                // every 5 loops (roughly 50 seconds), heartbeat
+                // skip first loop to avoid double-heartbeat when loopCount resets
+                if (loopCount != 0 && loopCount % 5 == 0)
+                {
+                    await Tasks.HeartbeatTasks.HeartbeatAsync();
+                }
 
                 // after 180 cycles, roughly 30 minutes has passed
                 if (loopCount == 180)

--- a/Tasks/HeartbeatTasks.cs
+++ b/Tasks/HeartbeatTasks.cs
@@ -1,34 +1,35 @@
-﻿using DSharpPlus.Net.Gateway;
-
-namespace Cliptok.Events
+namespace Cliptok.Tasks
 {
-    public class HeartbeatEvent
+    public class HeartbeatTasks
     {
-        public static async Task OnHeartbeat(IGatewayClient client)
+        public static async Task<bool> HeartbeatAsync()
         {
-            Program.discord.Logger.LogDebug("Heartbeat ping: {ping}", client.Ping.Milliseconds);
-            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("UPTIME_KUMA_PUSH_URL")) && client.IsConnected)
+            var ping = Program.discord.GetConnectionLatency(Program.homeGuild.Id).Milliseconds;
+            Program.discord.Logger.LogDebug("Heartbeat ping: {ping}", ping);
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("UPTIME_KUMA_PUSH_URL")) && Program.discord.AllShardsConnected)
             {
                 HttpResponseMessage response;
                 try
                 {
-                    response = await Program.httpClient.GetAsync(Environment.GetEnvironmentVariable("UPTIME_KUMA_PUSH_URL") + client.Ping.Milliseconds);
+                    response = await Program.httpClient.GetAsync(Environment.GetEnvironmentVariable("UPTIME_KUMA_PUSH_URL") + ping);
                 }
                 catch (Exception ex)
                 {
                     Program.discord.Logger.LogError(ex, "Uptime Kuma push failed during heartbeat event!");
-                    return;
+                    return false;
                 }
                 if (response.StatusCode == HttpStatusCode.OK)
                 {
                     Program.discord.Logger.LogDebug("Heartbeat ping succeeded.");
+                    return true;
                 }
                 else
                 {
                     Program.discord.Logger.LogError("Heartbeat ping sent: {status} {content}", (int)response.StatusCode, await response.Content.ReadAsStringAsync());
+                    return false;
                 }
-                return;
             }
+            return false;
         }
     }
 }


### PR DESCRIPTION
Upgrades D#+ to latest nightly. D#+ removed/changed some gateway stuff, so `IGatewayController` no longer exists. See https://github.com/DSharpPlus/DSharpPlus/pull/2444

This PR removes the implementation of `IGatewayController` we were using for the heartbeated & zombied events. Heartbeats to Uptime Kuma are now done with a scheduled task ~~that runs in the standard 10-second task loop~~ that runs about every 50 seconds. The zombied event is no longer handled here as D#+ should theoretically reconnect on its own