### PR TITLE
Tweak warning log reaction behavior

### DIFF
--- a/Events/MessageEvent.cs
+++ b/Events/MessageEvent.cs
@@ -748,7 +748,8 @@ namespace Cliptok.Events
                     null,
                     DiscordHelpers.MessageLink(message),
                     content: content,
-                    colour: new DiscordColor(0xFEC13D)
+                    colour: new DiscordColor(0xFEC13D),
+                    userWasWarned: true
                 );
             }
             #endregion
@@ -837,9 +838,9 @@ namespace Cliptok.Events
                     messageBuilder.WithContent(output);
                     DiscordMessage msg = await channel.SendMessageAsync(output);
 
-                    await InvestigationsHelpers.SendInfringingMessaageAsync("mod", message, reason, null, messageContentOverride: messageContentOverride);
+                    await InvestigationsHelpers.SendInfringingMessaageAsync("mod", message, reason, null, messageContentOverride: messageContentOverride, userWasWarned: true);
                     var warning = await WarningHelpers.GiveWarningAsync(message.Author, client.CurrentUser, reason, contextMessage: msg, channel, " automatically ");
-                    await InvestigationsHelpers.SendInfringingMessaageAsync("investigations", message, reason, warning.ContextLink, messageContentOverride: messageContentOverride);
+                    await InvestigationsHelpers.SendInfringingMessaageAsync("investigations", message, reason, warning.ContextLink, messageContentOverride: messageContentOverride, userWasWarned: true);
 
                     return true;
                 }
@@ -1064,13 +1065,13 @@ namespace Cliptok.Events
                     string reason = "Sent a malicious Discord invite";
 
                     DiscordMessage msg = await WarningHelpers.SendPublicWarningMessageAndDeleteInfringingMessageAsync(message, $"{Program.cfgjson.Emoji.Denied} {message.Author.Mention} was automatically warned: **{reason.Replace("`", "\\`").Replace("*", "\\*")}**", wasAutoModBlock);
-                    await InvestigationsHelpers.SendInfringingMessaageAsync("mod", message, reason, null, messageContentOverride: messageContentOverride, wasAutoModBlock: wasAutoModBlock);
+                    await InvestigationsHelpers.SendInfringingMessaageAsync("mod", message, reason, null, messageContentOverride: messageContentOverride, wasAutoModBlock: wasAutoModBlock, userWasWarned: true);
                     var warning = await WarningHelpers.GiveWarningAsync(message.Author, client.CurrentUser, reason, contextMessage: msg, channel, " automatically ");
 
                     string responseToSend = $"```json\n{JsonConvert.SerializeObject(maliciousCache)}\n```";
 
                     (string name, string value, bool inline) extraField = new("Cached API response", responseToSend, false);
-                    await InvestigationsHelpers.SendInfringingMessaageAsync("investigations", message, reason, warning.ContextLink, extraField, messageContentOverride: messageContentOverride, wasAutoModBlock: wasAutoModBlock);
+                    await InvestigationsHelpers.SendInfringingMessaageAsync("investigations", message, reason, warning.ContextLink, extraField, messageContentOverride: messageContentOverride, wasAutoModBlock: wasAutoModBlock, userWasWarned: true);
 
                     match = true;
                     break;
@@ -1319,9 +1320,9 @@ namespace Cliptok.Events
                         msg = await channel.SendMessageAsync(messageBuilder);
                     }
 
-                    await InvestigationsHelpers.SendInfringingMessaageAsync("mod", message, reason, null, messageContentOverride: messageContentOverride, wasAutoModBlock: wasAutoModBlock);
+                    await InvestigationsHelpers.SendInfringingMessaageAsync("mod", message, reason, null, messageContentOverride: messageContentOverride, wasAutoModBlock: wasAutoModBlock, userWasWarned: true);
                     var warning = await WarningHelpers.GiveWarningAsync(message.Author, client.CurrentUser, reason, contextMessage: msg, channel, " automatically ");
-                    await InvestigationsHelpers.SendInfringingMessaageAsync("investigations", message, reason, warning.ContextLink, messageContentOverride: messageContentOverride, wasAutoModBlock: wasAutoModBlock);
+                    await InvestigationsHelpers.SendInfringingMessaageAsync("investigations", message, reason, warning.ContextLink, messageContentOverride: messageContentOverride, wasAutoModBlock: wasAutoModBlock, userWasWarned: true);
 
                     return true;
                 }
@@ -1364,9 +1365,9 @@ namespace Cliptok.Events
                     messageBuilder.WithContent(output);
                     DiscordMessage msg = await channel.SendMessageAsync(output);
 
-                    await InvestigationsHelpers.SendInfringingMessaageAsync("mod", message, reason, null, messageContentOverride: messageContentOverride);
+                    await InvestigationsHelpers.SendInfringingMessaageAsync("mod", message, reason, null, messageContentOverride: messageContentOverride, userWasWarned: true);
                     var warning = await WarningHelpers.GiveWarningAsync(message.Author, client.CurrentUser, reason, contextMessage: msg, channel, " automatically ");
-                    await InvestigationsHelpers.SendInfringingMessaageAsync("investigations", message, reason, warning.ContextLink, messageContentOverride: messageContentOverride);
+                    await InvestigationsHelpers.SendInfringingMessaageAsync("investigations", message, reason, warning.ContextLink, messageContentOverride: messageContentOverride, userWasWarned: true);
 
                     return true;
                 }
@@ -1444,14 +1445,14 @@ namespace Cliptok.Events
 
             try
             {
-                _ = InvestigationsHelpers.SendInfringingMessaageAsync("mod", message, reason, null, wasAutoModBlock: wasAutoModBlock, messageContentOverride: messageContentOverride, useCodeBlock: useCodeBlock);
+                _ = InvestigationsHelpers.SendInfringingMessaageAsync("mod", message, reason, null, wasAutoModBlock: wasAutoModBlock, messageContentOverride: messageContentOverride, useCodeBlock: useCodeBlock, userWasWarned: true);
             }
             catch
             {
                 // still warn anyway
             }
             var warning = await WarningHelpers.GiveWarningAsync(message.Author, client.CurrentUser, reason, contextMessage: msg, channel, " automatically ");
-            await InvestigationsHelpers.SendInfringingMessaageAsync("investigations", message, reason, warning.ContextLink, extraField, messageContentOverride: messageContentOverride, wasAutoModBlock: wasAutoModBlock, useCodeBlock: useCodeBlock);
+            await InvestigationsHelpers.SendInfringingMessaageAsync("investigations", message, reason, warning.ContextLink, extraField, messageContentOverride: messageContentOverride, wasAutoModBlock: wasAutoModBlock, useCodeBlock: useCodeBlock, userWasWarned: true);
         }
 
         #endregion warning helpers
@@ -1581,13 +1582,13 @@ namespace Cliptok.Events
                 string reason = "Sent a malicious Discord invite";
 
                 DiscordMessage msg = await message.Channel.SendMessageAsync($"{Program.cfgjson.Emoji.Denied} {message.Author.Mention} was automatically warned: **{reason.Replace("`", "\\`").Replace("*", "\\*")}**");
-                await InvestigationsHelpers.SendInfringingMessaageAsync("mod", message, reason, null, messageContentOverride: messageContentOverride, wasAutoModBlock: wasAutoModBlock);
+                await InvestigationsHelpers.SendInfringingMessaageAsync("mod", message, reason, null, messageContentOverride: messageContentOverride, wasAutoModBlock: wasAutoModBlock, userWasWarned: true);
                 var warning = await WarningHelpers.GiveWarningAsync(message.Author, client.CurrentUser, reason, contextMessage: msg, message.Channel, " automatically ");
 
                 string responseToSend = $"```json\n{responseString}\n```";
 
                 (string name, string value, bool inline) extraField = new("API Response", responseToSend, false);
-                await InvestigationsHelpers.SendInfringingMessaageAsync("investigations", message, reason, warning.ContextLink, extraField, messageContentOverride: messageContentOverride, wasAutoModBlock: wasAutoModBlock);
+                await InvestigationsHelpers.SendInfringingMessaageAsync("investigations", message, reason, warning.ContextLink, extraField, messageContentOverride: messageContentOverride, wasAutoModBlock: wasAutoModBlock, userWasWarned: true);
 
                 var newEntry = JsonConvert.DeserializeObject<ServerApiResponseJson>(responseString);
                 newEntry.Invite = invite.Code;

--- a/Events/ReactionEvent.cs
+++ b/Events/ReactionEvent.cs
@@ -59,7 +59,7 @@ namespace Cliptok.Events
             var recycleBinEmoji = await discord.GetApplicationEmojiAsync(cfgjson.ReactionEmoji.Delete);
 
             // Ignore reactions that are not the CliptokRecycleBin emoji!!
-            if (e.Emoji != recycleBinEmoji)
+            if (e.Emoji.Name != "CliptokRecycleBin" && e.Emoji.Name != "WindowsRecycleBin")
                 return;
 
             if (e.Channel.Id == cfgjson.LogChannels["mod"].ChannelId)
@@ -150,13 +150,11 @@ namespace Cliptok.Events
                     }
                     if (!foundMatch)
                     {
-                        await targetMessage.CreateReactionAsync(errorEmoji);
                         return;
                     }
                 }
                 else if (matchingWarnings.Count < 1)
                 {
-                    await targetMessage.CreateReactionAsync(errorEmoji);
                     return;
                 }
                 else

--- a/Helpers/InvestigationsHelpers.cs
+++ b/Helpers/InvestigationsHelpers.cs
@@ -6,7 +6,7 @@
         {
             await SendInfringingMessaageAsync(logChannelKey, new MockDiscordMessage(infringingMessage), reason, messageURL, extraField, content, colour, channelOverride, messageContentOverride, wasAutoModBlock, useCodeBlock);
         }
-        public static async Task SendInfringingMessaageAsync(string logChannelKey, MockDiscordMessage infringingMessage, string reason, string messageURL, (string name, string value, bool inline) extraField = default, string content = default, DiscordColor? colour = null, DiscordChannel channelOverride = default, string messageContentOverride = default, bool wasAutoModBlock = false, bool useCodeBlock = false)
+        public static async Task SendInfringingMessaageAsync(string logChannelKey, MockDiscordMessage infringingMessage, string reason, string messageURL, (string name, string value, bool inline) extraField = default, string content = default, DiscordColor? colour = null, DiscordChannel channelOverride = default, string messageContentOverride = default, bool wasAutoModBlock = false, bool useCodeBlock = false, bool userWasWarned = false)
         {
             if (colour is null)
                 colour = new DiscordColor(0xf03916);
@@ -65,7 +65,7 @@
                 logMsg = await channelOverride.SendMessageAsync(new DiscordMessageBuilder().WithContent(content).AddEmbed(embed).WithAllowedMentions(Mentions.None));
 
             // Add reaction to log message to be used to delete
-            if (logChannelKey == "investigations" && channelOverride == default && Program.cfgjson.ReactionEmoji is not null)
+            if (logChannelKey == "investigations" && channelOverride == default && Program.cfgjson.ReactionEmoji is not null && userWasWarned)
             {
                 var emoji = await Program.discord.GetApplicationEmojiAsync(Program.cfgjson.ReactionEmoji.Delete);
                 await logMsg.CreateReactionAsync(emoji);


### PR DESCRIPTION
Slight tweaks to how Cliptok automatically reacts to warning log messages, and how it handles reactions from moderators. Closes #357. 

- Cliptok will not add a reaction to infringing message logs in investigations if the user was not issued a formal warning
- A warning will be deleted if reacted to with any emoji named CliptokRecycleBin or WindowsRecycleBin, instead of only accepting the emoji the bot reacted with. I believe this is how I originally intended this feature to behave, but this was unintentionally changed in a fix for another issue
- Cliptok will not react back with CliptokCritical if the warning does not exist. The intention is to respond with CliptokCritical if an error occurs, but moderators might manually react with a Recycle Bin emoji after manually removing a warning some other way—it's a bit awkward to have the bot respond with an error emoji in that case. It will still do so if a different error occurs