### PR TITLE
Keep cache of members not in server

### DIFF
--- a/Cliptok.csproj
+++ b/Cliptok.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net10.0</TargetFramework>
-		<LangVersion>13.0</LangVersion>
+		<LangVersion>14.0</LangVersion>
 		<UserSecretsId>d9345310-5908-4697-8613-28a24d06d183</UserSecretsId>
 
 		<InvariantGlobalization>false</InvariantGlobalization>

--- a/CommandChecks/HomeServerPerms.cs
+++ b/CommandChecks/HomeServerPerms.cs
@@ -86,14 +86,9 @@
                 if (ctx.Channel.IsPrivate || ctx.Guild.Id != Program.cfgjson.ServerID)
                 {
                     var guild = await ctx.Client.GetGuildAsync(Program.cfgjson.ServerID);
-                    try
-                    {
-                        member = await guild.GetMemberAsync(ctx.User.Id);
-                    }
-                    catch (DSharpPlus.Exceptions.NotFoundException)
-                    {
+                    member = await guild.CheckAndGetMemberAsync(ctx.User.Id);
+                    if (member is null)
                         return "The invoking user must be a member of the home server; they are not.";
-                    }
                 }
                 else
                 {

--- a/Commands/BanCmds.cs
+++ b/Commands/BanCmds.cs
@@ -65,7 +65,7 @@ namespace Cliptok.Commands
 
             try
             {
-                targetMember = await ctx.Guild.GetMemberAsync(user.Id);
+                targetMember = await ctx.Guild.CheckAndGetMemberAsync(user.Id);
                 if ((await GetPermLevelAsync(ctx.Member)) == ServerPermLevel.TrialModerator && ((await GetPermLevelAsync(targetMember)) >= ServerPermLevel.TrialModerator))
                 {
                     webhookOut.Content = $"{Program.cfgjson.Emoji.Error} As a Junior Moderator you cannot perform moderation actions on other staff members.";
@@ -102,7 +102,7 @@ namespace Cliptok.Commands
             DiscordMember member;
             try
             {
-                member = await ctx.Guild.GetMemberAsync(user.Id);
+                member = await ctx.Guild.CheckAndGetMemberAsync(user.Id);
             }
             catch
             {
@@ -120,7 +120,7 @@ namespace Cliptok.Commands
             {
                 if (DiscordHelpers.AllowedToMod(ctx.Member, member))
                 {
-                    if (DiscordHelpers.AllowedToMod(await ctx.Guild.GetMemberAsync(ctx.Client.CurrentUser.Id), member))
+                    if (DiscordHelpers.AllowedToMod(await ctx.Guild.CheckAndGetMemberAsync(ctx.Client.CurrentUser.Id), member))
                     {
                         if (userAlreadyBanned)
                             await BanHelpers.EditBanAsync(user.Id, ctx.User.Id, banDuration, reason, appealable);
@@ -264,7 +264,7 @@ namespace Cliptok.Commands
             DiscordMember member;
             try
             {
-                member = await ctx.Guild.GetMemberAsync(targetMember.Id);
+                member = await ctx.Guild.CheckAndGetMemberAsync(targetMember.Id);
             }
             catch
             {
@@ -288,7 +288,7 @@ namespace Cliptok.Commands
             {
                 if (DiscordHelpers.AllowedToMod(ctx.Member, member))
                 {
-                    if (DiscordHelpers.AllowedToMod(await ctx.Guild.GetMemberAsync(ctx.Client.CurrentUser.Id), member))
+                    if (DiscordHelpers.AllowedToMod(await ctx.Guild.CheckAndGetMemberAsync(ctx.Client.CurrentUser.Id), member))
                     {
                         await ctx.Message.DeleteAsync();
                         if (userAlreadyBanned)
@@ -389,7 +389,7 @@ namespace Cliptok.Commands
             DiscordMember member;
             try
             {
-                member = await ctx.Guild.GetMemberAsync(targetMember.Id);
+                member = await ctx.Guild.CheckAndGetMemberAsync(targetMember.Id);
             }
             catch
             {
@@ -413,7 +413,7 @@ namespace Cliptok.Commands
             {
                 if (DiscordHelpers.AllowedToMod(ctx.Member, member))
                 {
-                    if (DiscordHelpers.AllowedToMod(await ctx.Guild.GetMemberAsync(ctx.Client.CurrentUser.Id), member))
+                    if (DiscordHelpers.AllowedToMod(await ctx.Guild.CheckAndGetMemberAsync(ctx.Client.CurrentUser.Id), member))
                     {
                         await ctx.Message.DeleteAsync();
                         if (userAlreadyBanned)

--- a/Commands/ClearCmds.cs
+++ b/Commands/ClearCmds.cs
@@ -180,12 +180,8 @@
                 {
                     foreach (var message in messagesForChannel.Value)
                     {
-                        DiscordMember member;
-                        try
-                        {
-                            member = await ctx.Guild.GetMemberAsync(message.Author.Id);
-                        }
-                        catch (DSharpPlus.Exceptions.NotFoundException)
+                        var member = await ctx.Guild.CheckAndGetMemberAsync(message.Author.Id);
+                        if (member is null)
                         {
                             // User is not in the server, so they can't be a current mod
                             continue;

--- a/Commands/DebugCmds.cs
+++ b/Commands/DebugCmds.cs
@@ -9,6 +9,58 @@ namespace Cliptok.Commands
     {
         public static Dictionary<ulong, PendingUserOverride> OverridesPendingAddition = new();
 
+        [Command("membercache")]
+        [TextAlias("404cache")]
+        [IsBotOwner]
+        public class MemberCache
+        {
+            [DefaultGroupCommand]
+            [Command("list")]
+            [Description("Lists the members known to not be in the server.")]
+            public static async Task ListMemberCache(TextCommandContext ctx)
+            {
+                if (DiscordGuildExtensions.UsersNotInServerCache.Count < 1)
+                {
+                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} The cache is empty!");
+                    return;
+                }
+
+                var list = (await StringHelpers.CodeOrHasteBinAsync(string.Join("\n",
+                    DiscordGuildExtensions.UsersNotInServerCache.Select(userId => $"{userId} <@{userId}>")), noCode: true)).Text;
+
+                await ctx.RespondAsync(new DiscordMessageBuilder()
+                    .WithContent(list)
+                    .WithAllowedMentions(Mentions.None));
+            }
+
+            [Command("check")]
+            [Description("Check whether a member is known to not be in the server.")]
+            public static async Task CheckMemberCache(TextCommandContext ctx, DiscordUser user)
+            {
+                var isInCache = DiscordGuildExtensions.UsersNotInServerCache.Contains(user.Id);
+                if (isInCache)
+                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} {user.Mention} is in the cache (they are not in the server).");
+                else
+                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} {user.Mention} is not in the cache (they might be in the server).");
+            }
+
+            [Command("clear")]
+            [TextAlias("purge", "erase")]
+            [Description("Clears the cache of members known to not be in the server.")]
+            public static async Task ClearMemberCache(TextCommandContext ctx)
+            {
+                if (DiscordGuildExtensions.UsersNotInServerCache.Count < 1)
+                {
+                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} The cache is already empty!");
+                }
+                else
+                {
+                    DiscordGuildExtensions.UsersNotInServerCache = [];
+                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Success} Cache cleared!");   
+                }
+            }
+        }
+
         [Command("logprint")]
         public async Task LogPrint(TextCommandContext ctx)
         {
@@ -590,12 +642,8 @@ namespace Cliptok.Commands
                 var msg = await ctx.GetResponseAsync();
 
                 // Try fetching member to determine whether they are in the server. If they are not, we can't apply overrides for them.
-                DiscordMember member;
-                try
-                {
-                    member = await ctx.Guild.GetMemberAsync(user.Id);
-                }
-                catch (DSharpPlus.Exceptions.NotFoundException)
+                var member = await ctx.Guild.CheckAndGetMemberAsync(user.Id);
+                if (member is null)
                 {
                     await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} That user isn't in the server! I can't apply overrides for them.");
                     return;

--- a/Commands/DehoistCmds.cs
+++ b/Commands/DehoistCmds.cs
@@ -8,12 +8,8 @@ namespace Cliptok.Commands
         [HomeServer, RequireHomeserverPerm(ServerPermLevel.TrialModerator), RequirePermissions(permissions: DiscordPermission.ManageNicknames)]
         public async Task DehoistCmd(CommandContext ctx, [Parameter("member"), Description("The member to dehoist.")] DiscordUser user)
         {
-            DiscordMember member;
-            try
-            {
-                member = await ctx.Guild.GetMemberAsync(user.Id);
-            }
-            catch
+            var member = await ctx.Guild.CheckAndGetMemberAsync(user.Id);
+            if (member is null)
             {
                 await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} Failed to find {user.Mention} as a member! Are they in the server?", ephemeral: true);
                 return;

--- a/Commands/GlobalCmds.cs
+++ b/Commands/GlobalCmds.cs
@@ -335,14 +335,7 @@ namespace Cliptok.Commands
             if (ctx.Channel.IsPrivate || ctx.Guild.Id != Program.cfgjson.ServerID)
             {
                 var guild = await ctx.Client.GetGuildAsync(Program.cfgjson.ServerID);
-                try
-                {
-                    member = await guild.GetMemberAsync(ctx.User.Id);
-                }
-                catch (DSharpPlus.Exceptions.NotFoundException)
-                {
-                    // member is null, remember this for later
-                }
+                member = await guild.CheckAndGetMemberAsync(ctx.User.Id);
             }
             else
             {

--- a/Commands/KickCmds.cs
+++ b/Commands/KickCmds.cs
@@ -20,12 +20,8 @@ namespace Cliptok.Commands
 
             reason = reason.Replace("`", "\\`").Replace("*", "\\*");
 
-            DiscordMember member;
-            try
-            {
-                member = await ctx.Guild.GetMemberAsync(target.Id);
-            }
-            catch
+            var member = await ctx.Guild.CheckAndGetMemberAsync(target.Id);
+            if (member is null)
             {
                 await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} That user doesn't appear to be in the server!");
                 return;
@@ -33,7 +29,7 @@ namespace Cliptok.Commands
 
             if (DiscordHelpers.AllowedToMod(ctx.Member, member))
             {
-                if (DiscordHelpers.AllowedToMod(await ctx.Guild.GetMemberAsync(ctx.Client.CurrentUser.Id), member))
+                if (DiscordHelpers.AllowedToMod(await ctx.Guild.CheckAndGetMemberAsync(ctx.Client.CurrentUser.Id), member))
                 {
                     await KickHelpers.KickAndLogAsync(member, reason, ctx.Member);
                     await ctx.Channel.SendMessageAsync($"{Program.cfgjson.Emoji.Ejected} {target.Mention} has been kicked: **{reason}**");

--- a/Commands/MassCmds.cs
+++ b/Commands/MassCmds.cs
@@ -86,7 +86,7 @@ namespace Cliptok.Commands
             {
                 try
                 {
-                    var member = await ctx.Guild.GetMemberAsync(user);
+                    var member = await ctx.Guild.CheckAndGetMemberAsync(user);
                     if (member is not null)
                     {
 
@@ -270,12 +270,8 @@ namespace Cliptok.Commands
                 foreach (string strID in list)
                 {
                     ulong id = Convert.ToUInt64(strID);
-                    DiscordMember member = default;
-                    try
-                    {
-                        member = await ctx.Guild.GetMemberAsync(id);
-                    }
-                    catch (DSharpPlus.Exceptions.NotFoundException)
+                    var member = await ctx.Guild.CheckAndGetMemberAsync(id);
+                    if (member is null)
                     {
                         failedCount++;
                         continue;

--- a/Commands/MuteCmds.cs
+++ b/Commands/MuteCmds.cs
@@ -41,15 +41,7 @@ namespace Cliptok.Commands
             };
 
             await ctx.DeferResponseAsync(ephemeral: true);
-            DiscordMember targetMember = default;
-            try
-            {
-                targetMember = await ctx.Guild.GetMemberAsync(targetUser.Id);
-            }
-            catch (DSharpPlus.Exceptions.NotFoundException)
-            {
-                // is this worth logging?
-            }
+            var targetMember = await ctx.Guild.CheckAndGetMemberAsync(targetUser.Id);
 
             if (targetMember != default && (await GetPermLevelAsync(ctx.Member)) == ServerPermLevel.TrialModerator && ((await GetPermLevelAsync(targetMember)) >= ServerPermLevel.TrialModerator || targetMember.IsBot))
             {
@@ -104,15 +96,9 @@ namespace Cliptok.Commands
             if (Program.cfgjson.TqsMutedRole != 0)
                 tqsMutedRole = await ctx.Guild.GetRoleAsync(Program.cfgjson.TqsMutedRole);
 
-            DiscordMember member = default;
-            try
-            {
-                member = await ctx.Guild.GetMemberAsync(targetUser.Id);
-            }
-            catch (DSharpPlus.Exceptions.NotFoundException ex)
-            {
-                Program.discord.Logger.LogWarning(eventId: Program.CliptokEventID, exception: ex, message: "Failed to unmute user {user} in {server} because they weren't in the server.", targetUser.Id, ctx.Guild.Name);
-            }
+            var member = await ctx.Guild.CheckAndGetMemberAsync(targetUser.Id);
+            if (member is null)
+                Program.discord.Logger.LogWarning(eventId: Program.CliptokEventID, message: "Failed to unmute user {user} in {server} because they weren't in the server.", targetUser.Id, ctx.Guild.Name);
 
             if ((await Program.redis.HashExistsAsync("mutes", targetUser.Id)) || (member != default && (member.Roles.Contains(mutedRole) || member.Roles.Contains(tqsMutedRole))))
             {
@@ -176,15 +162,7 @@ namespace Cliptok.Commands
                 Stub = true
             };
 
-            DiscordMember targetMember = default;
-            try
-            {
-                targetMember = await ctx.Guild.GetMemberAsync(targetUser.Id);
-            }
-            catch (DSharpPlus.Exceptions.NotFoundException)
-            {
-                // is this worth logging?
-            }
+            var targetMember = await ctx.Guild.CheckAndGetMemberAsync(targetUser.Id);
 
             if (targetMember != default && ((await GetPermLevelAsync(ctx.Member))) == ServerPermLevel.TrialModerator && ((await GetPermLevelAsync(targetMember)) >= ServerPermLevel.TrialModerator || targetMember.IsBot))
             {
@@ -289,7 +267,7 @@ namespace Cliptok.Commands
 
             try
             {
-                var targetMember = await guild.GetMemberAsync(targetUser.Id);
+                var targetMember = await guild.CheckAndGetMemberAsync(targetUser.Id);
                 await targetMember.TimeoutAsync(mute.ExpireTime + TimeSpan.FromSeconds(10), mute.Reason);
             }
             catch (Exception e)

--- a/Commands/NicknameLockCmds.cs
+++ b/Commands/NicknameLockCmds.cs
@@ -14,7 +14,7 @@ namespace Cliptok.Commands
 
             try
             {
-                member = await ctx.Guild.GetMemberAsync(discordUser.Id);
+                member = await ctx.Guild.CheckAndGetMemberAsync(discordUser.Id);
             }
             catch (Exception e)
             {
@@ -68,7 +68,7 @@ namespace Cliptok.Commands
 
             try
             {
-                member = await ctx.Guild.GetMemberAsync(discordUser.Id);
+                member = await ctx.Guild.CheckAndGetMemberAsync(discordUser.Id);
             }
             catch (Exception e)
             {

--- a/Commands/TechSupportCmds.cs
+++ b/Commands/TechSupportCmds.cs
@@ -179,7 +179,7 @@ namespace Cliptok.Commands
             // Try to DM the OP a link to their post so they can find it again
             try
             {
-                var member = await ctx.Guild.GetMemberAsync(channel.CreatorId);
+                var member = await ctx.Guild.CheckAndGetMemberAsync(channel.CreatorId);
                 await member.SendMessageAsync($"{Program.cfgjson.Emoji.Success} Your post **{channel.Name}** in <#{forum.Id}> has been marked as solved!\nIf you need to refer back to it, you can find it here: https://discord.com/channels/{channel.Guild.Id}/{channel.Id}");
             }
             catch
@@ -235,15 +235,7 @@ namespace Cliptok.Commands
             DiscordRole tqsMutedRole = await ctx.Guild.GetRoleAsync(Program.cfgjson.TqsMutedRole);
 
             // Get member
-            DiscordMember targetMember = default;
-            try
-            {
-                targetMember = await ctx.Guild.GetMemberAsync(targetUser.Id);
-            }
-            catch (DSharpPlus.Exceptions.NotFoundException)
-            {
-                // blah
-            }
+            var targetMember = await ctx.Guild.CheckAndGetMemberAsync(targetUser.Id);
 
             if (await Program.redis.HashExistsAsync("mutes", targetUser.Id) || (targetMember is not null && (targetMember.Roles.Contains(mutedRole) || targetMember.Roles.Contains(tqsMutedRole))))
             {
@@ -311,12 +303,8 @@ namespace Cliptok.Commands
             DiscordRole tqsMutedRole = await ctx.Guild.GetRoleAsync(Program.cfgjson.TqsMutedRole);
 
             // Get member
-            DiscordMember targetMember = default;
-            try
-            {
-                targetMember = await ctx.Guild.GetMemberAsync(targetUser.Id);
-            }
-            catch (DSharpPlus.Exceptions.NotFoundException)
+            var targetMember = await ctx.Guild.CheckAndGetMemberAsync(targetUser.Id);
+            if (targetMember is null)
             {
                 // couldn't fetch member, fail
                 if (ctx is SlashCommandContext)

--- a/Commands/UtilityCmds.cs
+++ b/Commands/UtilityCmds.cs
@@ -13,7 +13,7 @@ namespace Cliptok.Commands
             DiscordMember member = default;
             try
             {
-                member = await ctx.Guild.GetMemberAsync(user.Id);
+                member = await ctx.Guild.CheckAndGetMemberAsync(user.Id);
             }
             catch (Exception)
             {
@@ -21,7 +21,7 @@ namespace Cliptok.Commands
                 return;
             }
 
-            if (!DiscordHelpers.AllowedToMod(await ctx.Guild.GetMemberAsync(ctx.Client.CurrentUser.Id), member))
+            if (!DiscordHelpers.AllowedToMod(await ctx.Guild.CheckAndGetMemberAsync(ctx.Client.CurrentUser.Id), member))
             {
                 await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} I don't have permission to grant {member.Mention}! Check the role order.");
                 return;

--- a/Commands/WarningCmds.cs
+++ b/Commands/WarningCmds.cs
@@ -51,7 +51,7 @@ namespace Cliptok.Commands
 
             try
             {
-                targetMember = await ctx.Guild.GetMemberAsync(user.Id);
+                targetMember = await ctx.Guild.CheckAndGetMemberAsync(user.Id);
                 if ((await GetPermLevelAsync(ctx.Member)) == ServerPermLevel.TrialModerator && ((await GetPermLevelAsync(targetMember)) >= ServerPermLevel.TrialModerator || targetMember.IsBot))
                 {
                     webhookOut = new DiscordWebhookBuilder().WithContent($"{Program.cfgjson.Emoji.Error} As a Junior Moderator you cannot perform moderation actions on other staff members or bots.");
@@ -325,7 +325,7 @@ namespace Cliptok.Commands
             DiscordMember targetMember;
             try
             {
-                targetMember = await ctx.Guild.GetMemberAsync(targetUser.Id);
+                targetMember = await ctx.Guild.CheckAndGetMemberAsync(targetUser.Id);
                 if ((await GetPermLevelAsync(ctx.Member)) == ServerPermLevel.TrialModerator && ((await GetPermLevelAsync(targetMember)) >= ServerPermLevel.TrialModerator || targetMember.IsBot))
                 {
                     await ctx.Channel.SendMessageAsync($"{Program.cfgjson.Emoji.Error} {ctx.User.Mention}, as a Junior Moderator you cannot perform moderation actions on other staff members or bots.");
@@ -400,7 +400,7 @@ namespace Cliptok.Commands
             DiscordMember targetMember;
             try
             {
-                targetMember = await ctx.Guild.GetMemberAsync(targetUser.Id);
+                targetMember = await ctx.Guild.CheckAndGetMemberAsync(targetUser.Id);
                 if ((await GetPermLevelAsync(ctx.Member)) == ServerPermLevel.TrialModerator && ((await GetPermLevelAsync(targetMember)) >= ServerPermLevel.TrialModerator || targetMember.IsBot))
                 {
                     await ctx.Channel.SendMessageAsync($"{Program.cfgjson.Emoji.Error} {ctx.User.Mention}, as a Junior Moderator you cannot perform moderation actions on other staff members or bots.");

--- a/Events/InteractionEvents.cs
+++ b/Events/InteractionEvents.cs
@@ -240,7 +240,7 @@ namespace Cliptok.Events
                 await e.Interaction.DeferAsync(ephemeral: true);
 
                 // Fetch member
-                var member = await e.Guild.GetMemberAsync(e.User.Id);
+                var member = await e.Guild.CheckAndGetMemberAsync(e.User.Id);
 
                 List<DiscordSelectComponentOption> menuOptions = [];
                 foreach (var roleId in Program.cfgjson.InsiderRoles)
@@ -269,7 +269,7 @@ namespace Cliptok.Events
                 await e.Interaction.DeferAsync(ephemeral: true);
 
                 // Get member
-                var member = await e.Guild.GetMemberAsync(e.User.Id);
+                var member = await e.Guild.CheckAndGetMemberAsync(e.User.Id);
 
                 // Get a list of the member's current roles that we can add to or remove from
                 // Then we can apply this in a single request with member.ModifyAsync to avoid making repeated member update requests
@@ -317,7 +317,7 @@ namespace Cliptok.Events
                 await e.Interaction.DeferAsync(ephemeral: true);
 
                 // Get member
-                var member = await e.Guild.GetMemberAsync(e.User.Id);
+                var member = await e.Guild.CheckAndGetMemberAsync(e.User.Id);
 
                 // Get insider chat role
                 var insiderChatRole = await e.Guild.GetRoleAsync(cfgjson.InsiderChatRole);
@@ -367,7 +367,7 @@ namespace Cliptok.Events
                 await e.Interaction.CreateResponseAsync(DiscordInteractionResponseType.DeferredMessageUpdate);
 
                 // Give member insider chat role
-                var member = await e.Guild.GetMemberAsync(e.User.Id);
+                var member = await e.Guild.CheckAndGetMemberAsync(e.User.Id);
                 var insiderChatRole = await e.Guild.GetRoleAsync(cfgjson.InsiderChatRole);
                 await member.GrantRoleAsync(insiderChatRole, $"Insiders chat access role selected in #{e.Channel.Name}");
 
@@ -382,7 +382,7 @@ namespace Cliptok.Events
                 await e.Interaction.CreateResponseAsync(DiscordInteractionResponseType.DeferredMessageUpdate);
 
                 // Get member
-                var member = await e.Guild.GetMemberAsync(e.User.Id);
+                var member = await e.Guild.CheckAndGetMemberAsync(e.User.Id);
 
                 var insiderChatRole = await e.Guild.GetRoleAsync(cfgjson.InsiderChatRole);
                 await member.RevokeRoleAsync(insiderChatRole, $"Insiders chat access role removed in #{e.Channel.Name}");

--- a/Events/MemberEvents.cs
+++ b/Events/MemberEvents.cs
@@ -11,6 +11,8 @@ namespace Cliptok.Events
             if (e.Guild.Id != cfgjson.ServerID)
                 return;
 
+            DiscordGuildExtensions.UsersNotInServerCache.Remove(e.Member.Id);
+
             var userLogEmbed = new DiscordEmbedBuilder()
                .WithColor(new DiscordColor(0x3E9D28))
                .WithTimestamp(DateTimeOffset.Now)
@@ -109,6 +111,8 @@ namespace Cliptok.Events
 
             if (e.Guild.Id != cfgjson.ServerID)
                 return;
+
+            DiscordGuildExtensions.UsersNotInServerCache.Add(e.Member.Id);
 
             // Attempt to check if member is cached
             bool isMemberCached = client.Guilds[e.Guild.Id].Members.ContainsKey(e.Member.Id);
@@ -331,7 +335,7 @@ namespace Cliptok.Events
             if (e.UserAfter.IsBot)
                 return;
 
-            var member = await homeGuild.GetMemberAsync(e.UserAfter.Id);
+            var member = await homeGuild.CheckAndGetMemberAsync(e.UserAfter.Id);
 
             // Nickname lock check
             var nicknamelock = await redis.HashGetAsync("nicknamelock", member.Id);

--- a/Events/MessageEvent.cs
+++ b/Events/MessageEvent.cs
@@ -294,15 +294,7 @@ namespace Cliptok.Events
                 #endregion
 
                 #region retrieve member object
-                DiscordMember member;
-                try
-                {
-                    member = await channel.Guild.GetMemberAsync(message.Author.Id);
-                }
-                catch (DSharpPlus.Exceptions.NotFoundException)
-                {
-                    member = default;
-                }
+                var member = await channel.Guild.CheckAndGetMemberAsync(message.Author.Id);
 
                 if (member == default)
                     return;
@@ -621,15 +613,9 @@ namespace Cliptok.Events
             {
                 Program.discord.Logger.LogDebug(Program.CliptokEventID, "Processing modmail message {message} in {channel}", message.Id, channel);
                 var idString = modmaiL_rx.Match(message.Embeds[0].Footer.Text).Groups[1].Captures[0].Value;
-                DiscordMember modmailMember = default;
-                try
-                {
-                    modmailMember = await channel.Guild.GetMemberAsync(Convert.ToUInt64(idString));
-                }
-                catch (DSharpPlus.Exceptions.NotFoundException)
-                {
+                var modmailMember = await channel.Guild.CheckAndGetMemberAsync(Convert.ToUInt64(idString));
+                if (modmailMember is null)
                     return;
-                }
 
                 DiscordMessageBuilder memberWarnInfo = new();
 

--- a/Events/ReactionEvent.cs
+++ b/Events/ReactionEvent.cs
@@ -52,7 +52,7 @@ namespace Cliptok.Events
             if (cfgjson.ReactionEmoji is null)
                 return;
 
-            var member = await e.Guild.GetMemberAsync(e.User.Id);
+            var member = await e.Guild.CheckAndGetMemberAsync(e.User.Id);
             if (await GetPermLevelAsync(member) < ServerPermLevel.TrialModerator)
                 return;
 

--- a/Events/VoiceEvents.cs
+++ b/Events/VoiceEvents.cs
@@ -126,7 +126,7 @@
             var channelAfter = e.After is null ? null : await e.After.GetChannelAsync();
             var user = await e.GetUserAsync();
             var guild = await e.GetGuildAsync();
-            var member = await guild.GetMemberAsync(user.Id);
+            var member = await guild.CheckAndGetMemberAsync(user.Id);
 
             if (Program.cfgjson.IgnoredVoiceChannels.Contains(channelAfter.Id))
                 return;
@@ -190,7 +190,7 @@
             var channelBefore = e.Before is null ? null : await e.Before.GetChannelAsync();
             var user = await e.GetUserAsync();
             var guild = await e.GetGuildAsync();
-            var member = await guild.GetMemberAsync(user.Id);
+            var member = await guild.CheckAndGetMemberAsync(user.Id);
 
             if (Program.cfgjson.IgnoredVoiceChannels.Contains(channelBefore.Id))
                 return;

--- a/Extensions/DiscordGuildExtensions.cs
+++ b/Extensions/DiscordGuildExtensions.cs
@@ -1,0 +1,30 @@
+namespace Cliptok.Extensions
+{
+    public static class DiscordGuildExtensions
+    {
+        internal static List<ulong> UsersNotInServerCache = [];
+
+        extension(DiscordGuild guild)
+        {
+            public async Task<DiscordMember> CheckAndGetMemberAsync(ulong userId, bool updateCache = false)
+            {
+                if (UsersNotInServerCache.Contains(userId))
+                    return null;
+
+                DiscordMember member;
+                try
+                {
+                    member = await guild.GetMemberAsync(userId, updateCache);
+                    UsersNotInServerCache.Remove(member.Id);
+                }
+                catch (DSharpPlus.Exceptions.NotFoundException)
+                {
+                    UsersNotInServerCache.Add(userId);
+                    return null;
+                }
+
+                return member;
+            }
+        }
+    }
+}

--- a/GlobalUsings.cs
+++ b/GlobalUsings.cs
@@ -2,6 +2,7 @@
 global using Cliptok.CommandChecks;
 global using Cliptok.Enums;
 global using Cliptok.Events;
+global using Cliptok.Extensions;
 global using Cliptok.Helpers;
 global using Cliptok.Types;
 global using DSharpPlus;

--- a/Helpers/BanHelpers.cs
+++ b/Helpers/BanHelpers.cs
@@ -9,7 +9,7 @@
             bool permaBan = false;
             DateTime? actionTime = DateTime.UtcNow;
             DateTime? expireTime = actionTime + banDuration;
-            DiscordMember moderator = await guild.GetMemberAsync(moderatorId);
+            DiscordMember moderator = await guild.CheckAndGetMemberAsync(moderatorId);
 
             if (reason.ToLower().Contains("compromised"))
                 compromisedAccount = true;
@@ -39,7 +39,7 @@
 
             try
             {
-                DiscordMember targetMember = await guild.GetMemberAsync(targetUserId);
+                DiscordMember targetMember = await guild.CheckAndGetMemberAsync(targetUserId);
                 if (permaBan)
                 {
                     if (appealable)

--- a/Helpers/DehoistHelpers.cs
+++ b/Helpers/DehoistHelpers.cs
@@ -92,7 +92,7 @@
             DiscordMember discordMember;
             try
             {
-                discordMember = await guild.GetMemberAsync(discordUser.Id);
+                discordMember = await guild.CheckAndGetMemberAsync(discordUser.Id);
             }
             catch
             {
@@ -150,7 +150,7 @@
                 DiscordMember discordMember;
                 try
                 {
-                    discordMember = await guild.GetMemberAsync(discordUser.Id);
+                    discordMember = await guild.CheckAndGetMemberAsync(discordUser.Id);
                 }
                 catch
                 {

--- a/Helpers/DiscordHelpers.cs
+++ b/Helpers/DiscordHelpers.cs
@@ -165,11 +165,8 @@ namespace Cliptok.Helpers
 
             string avatarUrl = await LykosAvatarMethods.UserOrMemberAvatarURL(user, guild, "default", 256);
 
-            try
-            {
-                member = await guild.GetMemberAsync(user.Id);
-            }
-            catch (DSharpPlus.Exceptions.NotFoundException)
+            member = await guild.CheckAndGetMemberAsync(user.Id);
+            if (member is null)
             {
                 embed = new DiscordEmbedBuilder()
                     .WithThumbnail(avatarUrl)
@@ -441,7 +438,7 @@ namespace Cliptok.Helpers
             {
                 try
                 {
-                    var member = await channel.Guild.GetMemberAsync(message.Author.Id);
+                    var member = await channel.Guild.CheckAndGetMemberAsync(message.Author.Id);
                     if ((await GetPermLevelAsync(member)) >= ServerPermLevel.TrialModerator)
                         return false;
                 }

--- a/Helpers/LykosAvatarMethods.cs
+++ b/Helpers/LykosAvatarMethods.cs
@@ -43,11 +43,9 @@
                     "either give none or one of the following: `gif`, `png`, `jpg`, `webp`");
             }
 
-            try
-            {
-                return MemberAvatarURL(await guild.GetMemberAsync(user.Id), format, size);
-            }
-            catch (DSharpPlus.Exceptions.NotFoundException)
+            var member = await guild.CheckAndGetMemberAsync(user.Id);
+            
+            if (member is null)
             {
                 string hash = user.AvatarHash;
 
@@ -66,6 +64,8 @@
 
                 return $"https://cdn.discordapp.com/avatars/{user.Id}/{user.AvatarHash}.{format}?size={size}";
             }
+
+            return MemberAvatarURL(member, format, size);
 
         }
 

--- a/Helpers/MuteHelpers.cs
+++ b/Helpers/MuteHelpers.cs
@@ -19,14 +19,7 @@
                     await LykosAvatarMethods.UserOrMemberAvatarURL(user, Program.homeGuild, "png")
                 );
 
-            try
-            {
-                member = await guild.GetMemberAsync(user.Id);
-            }
-            catch (DSharpPlus.Exceptions.NotFoundException)
-            {
-                // nothing
-            }
+            member = await guild.CheckAndGetMemberAsync(user.Id);
 
             if (await Program.redis.HashExistsAsync("mutes", user.Id))
             {
@@ -111,19 +104,11 @@
                 ? await guild.GetRoleAsync(Program.cfgjson.TqsMutedRole)
                 : await guild.GetRoleAsync(Program.cfgjson.MutedRole);
             DateTime? expireTime = actionTime + muteDuration;
-            DiscordMember moderator = await guild.GetMemberAsync(moderatorId);
+            DiscordMember moderator = await guild.CheckAndGetMemberAsync(moderatorId);
 
             (DiscordMessage? dmMessage, DiscordMessage? chatMessage) output = new();
 
-            DiscordMember naughtyMember = default;
-            try
-            {
-                naughtyMember = await guild.GetMemberAsync(naughtyUser.Id);
-            }
-            catch (DSharpPlus.Exceptions.NotFoundException)
-            {
-                // nothing
-            }
+            var naughtyMember = await guild.CheckAndGetMemberAsync(naughtyUser.Id);
 
             if (muteDuration == default)
             {
@@ -333,7 +318,9 @@
             {
                 // this should pull from cache most of the time!
                 var mutedRole = await targetGuild.GetRoleAsync(Program.cfgjson.MutedRole);
-                var member = await targetGuild.GetMemberAsync(targetUserId);
+                var member = await targetGuild.CheckAndGetMemberAsync(targetUserId);
+                if (member is null)
+                    return false;
                 await member.GrantRoleAsync(mutedRole, reason);
                 
                 MemberPunishment newMute = new()
@@ -362,7 +349,7 @@
             {
                 // this should pull from cache most of the time!
                 var mutedRole = await targetGuild.GetRoleAsync(Program.cfgjson.MutedRole);
-                var member = await targetGuild.GetMemberAsync(targetUserId);
+                var member = await targetGuild.CheckAndGetMemberAsync(targetUserId);
                 await member.RevokeRoleAsync(mutedRole, reason);
                 
                 await Program.redis.HashDeleteAsync("mutes", targetUserId);
@@ -392,15 +379,9 @@
             if (Program.cfgjson.TqsMutedRole != 0)
                 tqsMutedRole = await Program.homeGuild.GetRoleAsync(Program.cfgjson.TqsMutedRole);
 
-            DiscordMember member = default;
-            try
-            {
-                member = await guild.GetMemberAsync(targetUser.Id);
-            }
-            catch (DSharpPlus.Exceptions.NotFoundException ex)
-            {
-                Program.discord.Logger.LogWarning(eventId: Program.CliptokEventID, exception: ex, message: "Failed to unmute user {user} in {servername} because they weren't in the server.", targetUser.Id, guild.Name);
-            }
+            var member = await guild.CheckAndGetMemberAsync(targetUser.Id);
+            if (member is null)
+                Program.discord.Logger.LogWarning(eventId: Program.CliptokEventID, message: "Failed to unmute user {user} in {servername} because they weren't in the server.", targetUser.Id, guild.Name);
 
             if (member == default)
             {

--- a/Helpers/WarningHelpers.cs
+++ b/Helpers/WarningHelpers.cs
@@ -225,17 +225,16 @@
             DiscordMessage? dmMessage = null;
             try
             {
-                DiscordMember member = await guild.GetMemberAsync(targetUser.Id);
-                dmMessage = await member.SendMessageAsync(await GenerateWarningDM(reason, channel.Guild, extraWord));
+                DiscordMember member = await guild.CheckAndGetMemberAsync(targetUser.Id);
+                if (member is null)
+                    Program.discord.Logger.LogWarning("Failed to send warning DM to user because they are not in the server: {user}", targetUser.Id);
+                else
+                    dmMessage = await member.SendMessageAsync(await GenerateWarningDM(reason, channel.Guild, extraWord));
             }
             catch (Exception e)
             {
                 // We failed to DM the user.
                 // Lets log this if it isn't a known cause.
-                if (e is DSharpPlus.Exceptions.NotFoundException)
-                {
-                    Program.discord.Logger.LogWarning(e, "Failed to send warning DM to user because they are not in the server: {user}", targetUser.Id);
-                }
                 if (e is not DSharpPlus.Exceptions.UnauthorizedException)
                 {
                     Program.discord.Logger.LogWarning(e, "Failed to send warning DM to user: {user}", targetUser.Id);

--- a/Tasks/EventTasks.cs
+++ b/Tasks/EventTasks.cs
@@ -471,18 +471,7 @@ namespace Cliptok.Tasks
                 return false;
 
             // If the user isn't cached or banned, try fetching them to confirm
-            try
-            {
-                await guild.GetMemberAsync(userId);
-                isMemberInServer = true;
-            }
-            catch (DSharpPlus.Exceptions.NotFoundException)
-            {
-                // Member is not in the server
-                // isMemberInServer is already false
-
-                Program.discord.Logger.LogInformation(Program.CliptokEventID, "Failed to fetch member {userId} during override persistence checks. This and the accompanying 404 are expected if the user is not in the server.", userId);
-            }
+            isMemberInServer = (await guild.CheckAndGetMemberAsync(userId)) is not null;
 
             return isMemberInServer;
         }

--- a/Tasks/LockdownTasks.cs
+++ b/Tasks/LockdownTasks.cs
@@ -14,7 +14,7 @@
                 if (currentUnixTime >= unixExpiration)
                 {
                     var channel = await Program.discord.GetChannelAsync((ulong)channelUnlock.Name);
-                    var currentMember = await channel.Guild.GetMemberAsync(Program.discord.CurrentUser.Id);
+                    var currentMember = await channel.Guild.CheckAndGetMemberAsync(Program.discord.CurrentUser.Id);
                     await LockdownHelpers.UnlockChannel(channel, currentMember);
                     success = true;
                 }

--- a/Tasks/ReminderTasks.cs
+++ b/Tasks/ReminderTasks.cs
@@ -24,7 +24,7 @@
                     if (channel is null)
                     {
                         var guild = Program.homeGuild;
-                        var member = await guild.GetMemberAsync(reminderObject.UserID);
+                        var member = await guild.CheckAndGetMemberAsync(reminderObject.UserID);
 
                         if ((await GetPermLevelAsync(member)) >= ServerPermLevel.TrialModerator)
                         {


### PR DESCRIPTION
Closes #343 

Replaces all calls to `DiscordGuild.GetMemberAsync` with the added extension method `DiscordGuild.CheckAndGetMemberAsync`. This method checks against an in-memory cache of members who we know are not in the server. If the member is in the cache, the method returns null. If they are not, the method will try to fetch them—if they can be fetched, a member object is returned. If they cannot, it catches the NotFoundException and returns null.

Because this extension method catches all NotFoundExceptions and never throws its own, any try/catch around `GetMemberAsync` that had handling for a NotFoundException was replaced with a null check. In a couple of cases, this means that log messages that were thrown when a member could not be fetched will no longer include an exception, like this one:
> Failed to unmute user {user} in {server} because they weren't in the server

This PR upgrades C# to version 14 to use the `extension( ... )` syntax.

(also adds a couple of debug commands to check/manipulate the cache)