### PR TITLE
Set defaults for config values, prevent unexpected exceptions

### DIFF
--- a/CommandChecks/HomeServerPerms.cs
+++ b/CommandChecks/HomeServerPerms.cs
@@ -36,22 +36,29 @@
 
             bool HasRole(ulong roleId) => target.Roles.Any(r => r.Id == roleId);
 
-            return HasRole(Program.cfgjson.AdminRole) ? ServerPermLevel.Admin
-                : HasRole(Program.cfgjson.ModRole) ? ServerPermLevel.Moderator
-                : HasRole(Program.cfgjson.MutedRole) ? ServerPermLevel.Muted
-                : HasRole(Program.cfgjson.TrialModRole) ? ServerPermLevel.TrialModerator
-                : HasRole(Program.cfgjson.TqsRoleId) ? ServerPermLevel.TechnicalQueriesSlayer
-                : HasRole(Program.cfgjson.TierRoles[9]) ? ServerPermLevel.TierX
-                : HasRole(Program.cfgjson.TierRoles[8]) ? ServerPermLevel.TierS
-                : HasRole(Program.cfgjson.TierRoles[7]) ? ServerPermLevel.Tier8
-                : HasRole(Program.cfgjson.TierRoles[6]) ? ServerPermLevel.Tier7
-                : HasRole(Program.cfgjson.TierRoles[5]) ? ServerPermLevel.Tier6
-                : HasRole(Program.cfgjson.TierRoles[4]) ? ServerPermLevel.Tier5
-                : HasRole(Program.cfgjson.TierRoles[3]) ? ServerPermLevel.Tier4
-                : HasRole(Program.cfgjson.TierRoles[2]) ? ServerPermLevel.Tier3
-                : HasRole(Program.cfgjson.TierRoles[1]) ? ServerPermLevel.Tier2
-                : HasRole(Program.cfgjson.TierRoles[0]) ? ServerPermLevel.Tier1
-                : ServerPermLevel.Nothing;
+            try
+            {
+                return HasRole(Program.cfgjson.AdminRole) ? ServerPermLevel.Admin
+                    : HasRole(Program.cfgjson.ModRole) ? ServerPermLevel.Moderator
+                    : HasRole(Program.cfgjson.MutedRole) ? ServerPermLevel.Muted
+                    : HasRole(Program.cfgjson.TrialModRole) ? ServerPermLevel.TrialModerator
+                    : HasRole(Program.cfgjson.TqsRoleId) ? ServerPermLevel.TechnicalQueriesSlayer
+                    : HasRole(Program.cfgjson.TierRoles[9]) ? ServerPermLevel.TierX
+                    : HasRole(Program.cfgjson.TierRoles[8]) ? ServerPermLevel.TierS
+                    : HasRole(Program.cfgjson.TierRoles[7]) ? ServerPermLevel.Tier8
+                    : HasRole(Program.cfgjson.TierRoles[6]) ? ServerPermLevel.Tier7
+                    : HasRole(Program.cfgjson.TierRoles[5]) ? ServerPermLevel.Tier6
+                    : HasRole(Program.cfgjson.TierRoles[4]) ? ServerPermLevel.Tier5
+                    : HasRole(Program.cfgjson.TierRoles[3]) ? ServerPermLevel.Tier4
+                    : HasRole(Program.cfgjson.TierRoles[2]) ? ServerPermLevel.Tier3
+                    : HasRole(Program.cfgjson.TierRoles[1]) ? ServerPermLevel.Tier2
+                    : HasRole(Program.cfgjson.TierRoles[0]) ? ServerPermLevel.Tier1
+                    : ServerPermLevel.Nothing;
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                return ServerPermLevel.Nothing;
+            }
         }
 
         [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = false)]

--- a/Commands/AnnouncementCmds.cs
+++ b/Commands/AnnouncementCmds.cs
@@ -30,7 +30,12 @@ namespace Cliptok.Commands
             [Parameter("lockdown"), Description("Set 0 to not lock. Lock the channel for a certain period of time after announcing the build.")] string lockdownTime = "auto",
             [Parameter("force_reannounce"), Description("Whether to ignore the check for duplicate announcements and send this one anyway.")] bool forceReannounce = false)
         {
-            if (Program.cfgjson.InsidersChannel != 0 && ctx.Channel.Id != Program.cfgjson.InsidersChannel)
+            if (Program.cfgjson.InsidersChannel == 0)
+            {
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} The Insiders channel is not configured! Please contact a bot maintainer if this is unexpected.", ephemeral: true);
+                return;
+            }
+            else if (Program.cfgjson.InsidersChannel != 0 && ctx.Channel.Id != Program.cfgjson.InsidersChannel)
             {
                 await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} This command only works in <#{Program.cfgjson.InsidersChannel}>!", ephemeral: true);
                 return;

--- a/Commands/ClearCmds.cs
+++ b/Commands/ClearCmds.cs
@@ -274,12 +274,6 @@
                     messagesToClear.Remove(messagesForChannel.Key);
             }
 
-            if (messagesToClear.Count == 0)
-            {
-                await ctx.FollowupAsync(new DiscordFollowupMessageBuilder().WithContent($"{Program.cfgjson.Emoji.Error} All of the messages to delete are older than 2 weeks, so I can't delete them!").AsEphemeral(true));
-                return;
-            }
-
             // All filters checked. 'messagesToClear' is now our final list of messages to delete, by channel
 
             if (dryRun)
@@ -301,10 +295,10 @@
             }
             else
             {
-                await ctx.EditResponseAsync(new DiscordWebhookBuilder().WithContent($"{Program.cfgjson.Emoji.Loading} Deleting messages. This may take a while..."));
-
                 if (messagesToClear.Count >= 1)
                 {
+                    await ctx.EditResponseAsync(new DiscordWebhookBuilder().WithContent($"{Program.cfgjson.Emoji.Loading} Deleting messages. This may take a while..."));
+                    
                     foreach (var messagesForChannel in messagesToClear)
                     {
                         channel = ctx.Guild.Channels[messagesForChannel.Key];
@@ -332,7 +326,7 @@
                 }
                 else
                 {
-                    await ctx.EditResponseAsync(new DiscordWebhookBuilder().WithContent($"{Program.cfgjson.Emoji.Error} There were no messages that matched all of the arguments you provided! Nothing to do."));
+                    await ctx.EditResponseAsync(new DiscordWebhookBuilder().WithContent($"{Program.cfgjson.Emoji.Error} There were no messages sent less than 2 weeks ago that matched all of the arguments you provided! Nothing to do."));
                 }
             }
         }

--- a/Commands/ClearCmds.cs
+++ b/Commands/ClearCmds.cs
@@ -89,9 +89,15 @@
                 List<DiscordChannel> channelsToSearch;
                 if (multiChannel)
                 {
-                    var clearChannelIds = Program.cfgjson.PublicFacingChannels is not null
+                    var clearChannelIds = Program.cfgjson.PublicFacingChannels.Count > 0
                         ? Program.cfgjson.PublicFacingChannels
                         : Program.cfgjson.LockdownEnabledChannels;
+
+                    if (clearChannelIds.Count == 0)
+                    {
+                        await ctx.EditResponseAsync($"{Program.cfgjson.Emoji.Error} The list of public channels is missing, so multi-channel clear is unavailable! Please contact a bot maintainer if this is unexpected.");
+                        return;
+                    }
 
                     channelsToSearch = ctx.Guild.Channels.Values.Where(x => clearChannelIds.Contains(x.Id)).ToList();
                 }

--- a/Commands/LockdownCmds.cs
+++ b/Commands/LockdownCmds.cs
@@ -102,6 +102,12 @@ namespace Cliptok.Commands
             [Parameter("time"), Description("The length of time to lock the channels for.")] string time = null,
             [Parameter("lockthreads"), Description("Whether to lock threads. Disables sending messages, but does not archive them.")] bool lockThreads = false)
         {
+            if (Program.cfgjson.PublicFacingChannels.Count == 0)
+            {
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Denied} There are no lockdown channels configured! Please contact a bot maintainer if this is unexpected.");
+                return;
+            }
+
             if (ctx is SlashCommandContext)
                 await ctx.DeferResponseAsync();
 
@@ -201,8 +207,14 @@ namespace Cliptok.Commands
         [Description("Unlock all lockable channels in the server. See also: lockdown all")]
         public async Task UnlockAllCommand(CommandContext ctx, [Parameter("reason"), Description("The reason for the unlock.")] string reason = "")
         {
+            if (Program.cfgjson.PublicFacingChannels.Count == 0)
+            {
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Denied} There are no lockdown channels configured! Please contact a bot maintainer if this is unexpected.");
+                return;
+            }
+
             if (ctx is SlashCommandContext)
-                ctx.DeferResponseAsync();
+                await ctx.DeferResponseAsync();
 
             LockdownCmds.ongoingLockdown = true;
             if (ctx is SlashCommandContext)

--- a/Commands/TechSupportCmds.cs
+++ b/Commands/TechSupportCmds.cs
@@ -52,7 +52,7 @@ namespace Cliptok.Commands
             else
             {
                 message = $"**__Need Help Or Have a Problem{(user == default ? "" : $", {user.Mention}")}?__**\n" +
-                          $"You're probably looking for <#{Program.cfgjson.TechSupportChannel}> or <#{Program.cfgjson.SupportForumId}>!\n\n" +
+                          $"You're probably looking for <#{Program.cfgjson.TechSupportChannel}>{(Program.cfgjson.SupportForumId == 0 ? "" : $" or <#{Program.cfgjson.SupportForumId}>")}!\n\n" +
                           $"Once there, please be sure to provide **plenty of details,** follow the guidelines, ping the <@&{Program.cfgjson.CommunityTechSupportRoleID}> role, and *be patient!*\n\n" +
                           $"Look under the `🔧 Support` category for the appropriate channel for your issue. See <#413274922413195275> for more info.\n\n" +
                           $"**__Need Help With Your Account?__**\n" +
@@ -113,6 +113,12 @@ namespace Cliptok.Commands
         {
             await ctx.DeferResponseAsync(ephemeral: true);
 
+            if (Program.cfgjson.SupportForumId == 0)
+            {
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} The tech support forum channel is not configured! Please contact a bot maintainer.", ephemeral: true);
+                return;
+            }
+
             // Restrict to #tech-support-forum posts
             if (ctx.Channel.Parent is null || ctx.Channel.Parent.Id != Program.cfgjson.SupportForumId)
             {
@@ -126,7 +132,7 @@ namespace Cliptok.Commands
             // Restrict to OP or TQS members
             if (ctx.User.Id != channel.CreatorId && await GetPermLevelAsync(ctx.Member) < ServerPermLevel.TechnicalQueriesSlayer)
             {
-                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} Only the original poster or a <@&{Program.cfgjson.TqsRoleId}> can mark this post as solved!");
+                await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} Only the original poster{(Program.cfgjson.TqsRoleId == 0 ? "" : $" or a <@&{Program.cfgjson.TqsRoleId}>")} can mark this post as solved!");
                 return;
             }
 
@@ -215,17 +221,27 @@ namespace Cliptok.Commands
                 return;
             }
 
-            // Only allow usage in #tech-support, #tech-support-forum, and their threads + #bot-commands
-            if (ctx.Channel.Id != Program.cfgjson.TechSupportChannel &&
-                ctx.Channel.Id != Program.cfgjson.SupportForumId &&
-                ctx.Channel.Parent.Id != Program.cfgjson.TechSupportChannel &&
-                ctx.Channel.Parent.Id != Program.cfgjson.SupportForumId &&
-                ctx.Channel.Id != Program.cfgjson.BotCommandsChannel)
+            List<ulong> allowedChannels = [
+                Program.cfgjson.TechSupportChannel,
+                Program.cfgjson.SupportForumId,
+                Program.cfgjson.BotCommandsChannel
+            ];
+            allowedChannels.RemoveAll(x => x == 0);
+
+            if (allowedChannels.Count == 0)
             {
                 if (ctx is SlashCommandContext)
-                    await ctx.EditResponseAsync(new DiscordWebhookBuilder().WithContent($"{Program.cfgjson.Emoji.Error} This command can only be used in <#{Program.cfgjson.TechSupportChannel}>, <#{Program.cfgjson.SupportForumId}>, and threads in those channels!"));
+                    await ctx.EditResponseAsync(new DiscordWebhookBuilder().WithContent($"{Program.cfgjson.Emoji.Error} There are no allowed channels for this command! Please contact a bot maintainer."));
                 else
-                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} This command can only be used in <#{Program.cfgjson.TechSupportChannel}>, <#{Program.cfgjson.SupportForumId}>, and threads in those channels!");
+                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} There are no allowed channels for this command! Please contact a bot maintainer.");
+                return;
+            }
+            else if (!allowedChannels.Contains(ctx.Channel.Id) && !allowedChannels.Contains(ctx.Channel.Parent.Id))
+            {
+                if (ctx is SlashCommandContext)
+                    await ctx.EditResponseAsync(new DiscordWebhookBuilder().WithContent($"{Program.cfgjson.Emoji.Error} This command can only be used in {string.Join(", ", allowedChannels.Select(x => $"<#{x}>"))} and threads in {(allowedChannels.Count > 1 ? "those channels" : "that channel")}!"));
+                else
+                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} This command can only be used in {string.Join(", ", allowedChannels.Select(x => $"<#{x}>"))} and threads in {(allowedChannels.Count > 1 ? "those channels" : "that channel")}!");
                 return;
             }
 
@@ -285,16 +301,27 @@ namespace Cliptok.Commands
             }
 
             // Only allow usage in #tech-support, #tech-support-forum, and their threads + #bot-commands
-            if (ctx.Channel.Id != Program.cfgjson.TechSupportChannel &&
-                ctx.Channel.Id != Program.cfgjson.SupportForumId &&
-                ctx.Channel.Parent.Id != Program.cfgjson.TechSupportChannel &&
-                ctx.Channel.Parent.Id != Program.cfgjson.SupportForumId &&
-                ctx.Channel.Id != Program.cfgjson.BotCommandsChannel)
+            List<ulong> allowedChannels = [
+                Program.cfgjson.TechSupportChannel,
+                Program.cfgjson.SupportForumId,
+                Program.cfgjson.BotCommandsChannel
+            ];
+            allowedChannels.RemoveAll(x => x == 0);
+
+            if (allowedChannels.Count == 0)
             {
                 if (ctx is SlashCommandContext)
-                    await ctx.EditResponseAsync(new DiscordWebhookBuilder().WithContent($"{Program.cfgjson.Emoji.Error} This command can only be used in <#{Program.cfgjson.TechSupportChannel}>, <#{Program.cfgjson.SupportForumId}>, and threads in those channels!"));
+                    await ctx.EditResponseAsync(new DiscordWebhookBuilder().WithContent($"{Program.cfgjson.Emoji.Error} There are no allowed channels for this command! Please contact a bot maintainer."));
                 else
-                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} This command can only be used in <#{Program.cfgjson.TechSupportChannel}>, <#{Program.cfgjson.SupportForumId}>, their threads, and <#{Program.cfgjson.BotCommandsChannel}>!");
+                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} There are no allowed channels for this command! Please contact a bot maintainer.");
+                return;
+            }
+            else if (!allowedChannels.Contains(ctx.Channel.Id) && !allowedChannels.Contains(ctx.Channel.Parent.Id))
+            {
+                if (ctx is SlashCommandContext)
+                    await ctx.EditResponseAsync(new DiscordWebhookBuilder().WithContent($"{Program.cfgjson.Emoji.Error} This command can only be used in {string.Join(", ", allowedChannels.Select(x => $"<#{x}>"))} and threads in {(allowedChannels.Count > 1 ? "those channels" : "that channel")}!"));
+                else
+                    await ctx.RespondAsync($"{Program.cfgjson.Emoji.Error} This command can only be used in {string.Join(", ", allowedChannels.Select(x => $"<#{x}>"))} and threads in {(allowedChannels.Count > 1 ? "those channels" : "that channel")}!");
                 return;
             }
 

--- a/Events/InteractionEvents.cs
+++ b/Events/InteractionEvents.cs
@@ -240,6 +240,14 @@ namespace Cliptok.Events
             {
                 // Shows a menu in #insider-info that allows a user to toggle their Insider roles
 
+                if (Program.cfgjson.InsiderRoles.Count == 0)
+                {
+                    await e.Interaction.CreateResponseAsync(DiscordInteractionResponseType.ChannelMessageWithSource, new DiscordInteractionResponseBuilder()
+                        .WithContent($"{Program.cfgjson.Emoji.Error} Insider roles are not configured! Please contact a bot maintainer.")
+                        .AsEphemeral(true));
+                    return;
+                }
+
                 // Defer interaction
                 await e.Interaction.DeferAsync(ephemeral: true);
 
@@ -324,7 +332,18 @@ namespace Cliptok.Events
                 var member = await e.Guild.CheckAndGetMemberAsync(e.User.Id);
 
                 // Get insider chat role
-                var insiderChatRole = await e.Guild.GetRoleAsync(cfgjson.InsiderChatRole);
+                DiscordRole insiderChatRole;
+                try
+                {
+                    insiderChatRole = await e.Guild.GetRoleAsync(cfgjson.InsiderChatRole);
+                }
+                catch (DSharpPlus.Exceptions.NotFoundException)
+                {
+                    await e.Interaction.CreateFollowupMessageAsync(new DiscordFollowupMessageBuilder()
+                        .WithContent($"{Program.cfgjson.Emoji.Error} The Insider chat role is not set up! Please contact a bot maintainer."));
+                    return;
+                }
+
 
                 // Check whether member already has any insider roles
                 if (Program.cfgjson.InsiderRoles is not null && member.Roles.Any(x => Program.cfgjson.InsiderRoles.Contains(x.Id)))

--- a/Events/MessageEvent.cs
+++ b/Events/MessageEvent.cs
@@ -704,7 +704,8 @@ namespace Cliptok.Events
         {
             #region automatic listupdate for private lists
             if (
-                Program.cfgjson.GitListDirectory is not null
+                !string.IsNullOrEmpty(Program.cfgjson.GitListDirectory)
+                && !string.IsNullOrEmpty(Program.cfgjson.GithubWorkflowSucessString)
                 && Program.cfgjson.GitListDirectory != ""
                 && message.Channel.Id == Program.cfgjson.HomeChannel
                 && message.Author.Discriminator == "0000"
@@ -854,7 +855,7 @@ namespace Cliptok.Events
 
         private static async Task<bool> RunMassMentionsBanFilterAsync(DiscordClient client, MockDiscordMessage message, DiscordChannel channel, DiscordMember member, ServerPermLevel permLevel, string messageContentOverride = default, bool isAnEdit = false, bool limitFilters = false, bool wasAutoModBlock = false)
         {
-            if ((message.MentionedUsers is not null && message.MentionedUsers.Count > Program.cfgjson.MassMentionBanThreshold) || (message.MentionedUsersCount > Program.cfgjson.MassMentionBanThreshold))
+            if (Program.cfgjson.MassMentionBanThreshold > 0 && ((message.MentionedUsers is not null && message.MentionedUsers.Count > Program.cfgjson.MassMentionBanThreshold) || (message.MentionedUsersCount > Program.cfgjson.MassMentionBanThreshold)))
             {
                 if (wasAutoModBlock)
                 {
@@ -1118,7 +1119,7 @@ namespace Cliptok.Events
 
         private static async Task<bool> RunMassEmojiFilterAsync(DiscordClient client, MockDiscordMessage message, DiscordChannel channel, DiscordMember member, ServerPermLevel permLevel, string messageContentOverride = default, bool isAnEdit = false, bool limitFilters = false, bool wasAutoModBlock = false)
         {
-            if (!Program.cfgjson.UnrestrictedEmojiChannels.Contains(channel.Id) && messageContentOverride.Length >= Program.cfgjson.MassEmojiThreshold)
+            if (Program.cfgjson.MassEmojiThreshold > 0 && !Program.cfgjson.UnrestrictedEmojiChannels.Contains(channel.Id) && messageContentOverride.Length >= Program.cfgjson.MassEmojiThreshold)
             {
                 char[] tempArray = messageContentOverride.Replace("🏻", "").Replace("🏼", "").Replace("🏽", "").Replace("🏾", "").Replace("🏿", "").ToCharArray();
                 int pos = 0;
@@ -1240,7 +1241,7 @@ namespace Cliptok.Events
 
         private static async Task<bool> RunMassMentionsWarnFilterAsync(DiscordClient client, MockDiscordMessage message, DiscordChannel channel, DiscordMember member, ServerPermLevel permLevel, string messageContentOverride = default, bool isAnEdit = false, bool limitFilters = false, bool wasAutoModBlock = false)
         {
-            if (((message.MentionedUsers is not null && message.MentionedUsers.Count >= Program.cfgjson.MassMentionThreshold) || (message.MentionedUsersCount >= Program.cfgjson.MassMentionThreshold)) && permLevel < ServerPermLevel.Tier3)
+            if (Program.cfgjson.MassMentionThreshold > 0 && ((message.MentionedUsers is not null && message.MentionedUsers.Count >= Program.cfgjson.MassMentionThreshold) || (message.MentionedUsersCount >= Program.cfgjson.MassMentionThreshold)) && permLevel < ServerPermLevel.Tier3)
             {
                 if (wasAutoModBlock)
                 {
@@ -1260,11 +1261,14 @@ namespace Cliptok.Events
 
         private static async Task<bool> RunLineLimitFilterAsync(DiscordClient client, MockDiscordMessage message, DiscordChannel channel, DiscordMember member, ServerPermLevel permLevel, string messageContentOverride = default, bool isAnEdit = false, bool limitFilters = false, bool wasAutoModBlock = false)
         {
+            if (Program.cfgjson.LineLimit == 0)
+                return false;
+
             var lineCount = CountNewlines(messageContentOverride);
 
             if (!Program.cfgjson.LineLimitExcludedChannels.Contains(channel.Id)
                 && (channel.ParentId is null || !Program.cfgjson.LineLimitExcludedChannels.Contains((ulong)channel.ParentId))
-                && (lineCount >= Program.cfgjson.IncreasedLineLimit
+                && ((Program.cfgjson.IncreasedLineLimit > 0 && lineCount >= Program.cfgjson.IncreasedLineLimit)
                 || (lineCount >= Program.cfgjson.LineLimit && permLevel < (ServerPermLevel)Program.cfgjson.LineLimitTier)))
             {
                 if (wasAutoModBlock)

--- a/Events/ReactionEvent.cs
+++ b/Events/ReactionEvent.cs
@@ -46,7 +46,7 @@ namespace Cliptok.Events
             if (e.User.Id == discord.CurrentUser.Id)
                 return;
 
-            if (e.Channel.Id != cfgjson.LogChannels["investigations"].ChannelId && e.Channel.Id != cfgjson.LogChannels["mod"].ChannelId)
+            if (e.Channel.Id != LogChannelHelper.GetLogChannelId("investigations") && e.Channel.Id != LogChannelHelper.GetLogChannelId("mod"))
                 return;
 
             if (cfgjson.ReactionEmoji is null)

--- a/Events/ReadyEvent.cs
+++ b/Events/ReadyEvent.cs
@@ -69,7 +69,7 @@ namespace Cliptok.Events
             if (cfgjson.AutoWarnMsgAutoDeleteHours > 0 && cfgjson.AutoWarnMsgAutoDeleteDays > 0)
                 discord.Logger.LogWarning(CliptokEventID, "Both autoWarnMsgAutoDeleteHours and autoWarnMsgAutoDeleteDays are set. Hours will be used, please remove the old days config. Using {hours} hours.", cfgjson.AutoWarnMsgAutoDeleteHours);
 
-            if (cfgjson.PublicFacingChannels is not null && cfgjson.LockdownEnabledChannels is not null)
+            if (cfgjson.PublicFacingChannels.Count > 0 && cfgjson.LockdownEnabledChannels.Count > 0)
                 discord.Logger.LogWarning(CliptokEventID, "Both publicFacingChannels and lockdownEnabledChannels are set. publicFacingChannels will be used, please remove the old lockdown config.");
 
             Tasks.PunishmentTasks.CheckMutesAsync();

--- a/Helpers/BanHelpers.cs
+++ b/Helpers/BanHelpers.cs
@@ -42,7 +42,7 @@
                 DiscordMember targetMember = await guild.CheckAndGetMemberAsync(targetUserId);
                 if (permaBan)
                 {
-                    if (appealable)
+                    if (appealable && !string.IsNullOrEmpty(Program.cfgjson.AppealLink))
                     {
                         if (compromisedAccount)
                             output.dmMessage = await targetMember.SendMessageAsync($"{Program.cfgjson.Emoji.Banned} You have been banned from **{guild.Name}**!\nReason: **{reason}**\nYou can appeal the ban here: <{Program.cfgjson.AppealLink}>\nBefore appealing, please follow these steps to protect your account:\n1. Reset your Discord account password. Even if you use MFA, this will reset all session tokens.\n2. Review active sessions and authorised app connections.\n3. Ensure your PC is free of malware.\n4. [Enable MFA](https://support.discord.com/hc/en-us/articles/219576828-Setting-up-Multi-Factor-Authentication) if not already.");

--- a/Helpers/InvestigationsHelpers.cs
+++ b/Helpers/InvestigationsHelpers.cs
@@ -65,7 +65,7 @@
                 logMsg = await channelOverride.SendMessageAsync(new DiscordMessageBuilder().WithContent(content).AddEmbed(embed).WithAllowedMentions(Mentions.None));
 
             // Add reaction to log message to be used to delete
-            if (logChannelKey == "investigations" && channelOverride == default && Program.cfgjson.ReactionEmoji is not null && userWasWarned)
+            if (Program.cfgjson.WarningLogReactionTimeMinutes > 0 && logChannelKey == "investigations" && channelOverride == default && Program.cfgjson.ReactionEmoji is not null && userWasWarned)
             {
                 var emoji = await Program.discord.GetApplicationEmojiAsync(Program.cfgjson.ReactionEmoji.Delete);
                 await logMsg.CreateReactionAsync(emoji);

--- a/Helpers/WarningHelpers.cs
+++ b/Helpers/WarningHelpers.cs
@@ -109,11 +109,13 @@
                     );
 
                     embed.AddField($"Last {Program.cfgjson.RecentWarningsPeriodHours} hours", hourRecentMatches.Count().ToString(), true);
-
-                    embed.AddField($"Last {Program.cfgjson.WarningDaysThreshold} days", recentCount.ToString(), true)
-                        .AddField("Total", keys.Count().ToString(), true);
                 }
 
+                if (Program.cfgjson.WarningDaysThreshold != 0)
+                    embed.AddField($"Last {Program.cfgjson.WarningDaysThreshold} days", recentCount.ToString(), true);
+                
+                embed.AddField("Total", keys.Count().ToString(), true);
+                
                 embed.WithDescription(str);
             }
 
@@ -286,7 +288,7 @@
             );
             try
             {
-                if (Program.cfgjson.ReactionEmoji is not null)
+                if (Program.cfgjson.ReactionEmoji is not null && Program.cfgjson.WarningLogReactionTimeMinutes > 0)
                 {
                     var emoji = await Program.discord.GetApplicationEmojiAsync(Program.cfgjson.ReactionEmoji.Delete);
                     await logMsg.CreateReactionAsync(emoji);

--- a/Program.cs
+++ b/Program.cs
@@ -78,7 +78,7 @@ namespace Cliptok
                 .WriteTo.Console(outputTemplate: logFormat, theme: AnsiConsoleTheme.Literate)
                 .MinimumLevel.Override("System.Net.Http", LogEventLevel.Error);
 
-            string token;
+            string token = "";
             var json = "";
 
             string configFile = "config.json";
@@ -142,13 +142,21 @@ namespace Cliptok
 
             avatars = File.ReadAllLines("Lists/avatars.txt");
 
-            if (Environment.GetEnvironmentVariable("CLIPTOK_TOKEN") is not null)
+            if (Environment.GetEnvironmentVariable("CLIPTOK_TOKEN") is null && Program.cfgjson.Core.Token is null)
+            {
+                throw new ArgumentException("Bot token is missing. Set token in config.json or with CLIPTOK_TOKEN environment variable.");
+            }
+            else if (Environment.GetEnvironmentVariable("CLIPTOK_TOKEN") is not null)
                 token = Environment.GetEnvironmentVariable("CLIPTOK_TOKEN");
             else
                 token = cfgjson.Core.Token;
 
             if (Environment.GetEnvironmentVariable("REDIS_URL") is not null)
                 redisConnection = ConnectionMultiplexer.Connect(Environment.GetEnvironmentVariable("REDIS_URL"));
+            else if (Program.cfgjson.Redis is null)
+            {
+                throw new ArgumentException("Redis configuration is missing. Set redis host and port in config.json or with REDIS_URL environment variable.");
+            }
             else
             {
                 string redisHost;

--- a/Types/Config.cs
+++ b/Types/Config.cs
@@ -3,19 +3,19 @@
     public class ConfigJson
     {
         [JsonProperty("core")]
-        public CoreConfig Core { get; private set; }
+        public CoreConfig Core { get; private set; } = new();
 
         [JsonProperty("redis")]
-        public RedisConfig Redis { get; private set; }
+        public RedisConfig Redis { get; private set; } = null;
 
         [JsonProperty("trialModRole")]
-        public ulong TrialModRole { get; private set; }
+        public ulong TrialModRole { get; private set; } = 0;
 
         [JsonProperty("modRole")]
-        public ulong ModRole { get; private set; }
+        public ulong ModRole { get; private set; } = 0;
 
         [JsonProperty("adminRole")]
-        public ulong AdminRole { get; private set; }
+        public ulong AdminRole { get; private set; } = 0;
 
         [JsonProperty("logChannel")]
         public ulong LogChannel { get; private set; } = 0;
@@ -24,85 +24,85 @@
         public ulong UserLogChannel { get; private set; } = 0;
 
         [JsonProperty("serverID")]
-        public ulong ServerID { get; private set; }
+        public ulong ServerID { get; private set; } = 0;
 
         [JsonProperty("homeChannel")]
         public ulong HomeChannel { get; private set; } = 0;
 
         [JsonProperty("emoji")]
-        public EmojiJson Emoji { get; private set; }
+        public EmojiJson Emoji { get; private set; } = new();
 
         [JsonProperty("mutedRole")]
-        public ulong MutedRole { get; private set; }
+        public ulong MutedRole { get; private set; } = 0;
 
         [JsonProperty("warningDaysThreshold")]
-        public int WarningDaysThreshold { get; private set; }
+        public int WarningDaysThreshold { get; private set; } = 0;
 
         [JsonProperty("autoMuteThresholds")]
-        public Dictionary<string, int> AutoMuteThresholds { get; private set; }
+        public Dictionary<string, int> AutoMuteThresholds { get; private set; } = new();
 
         [JsonProperty("recentWarningsPeriodHours")]
-        public int RecentWarningsPeriodHours { get; private set; }
+        public int RecentWarningsPeriodHours { get; private set; } = 0;
 
         [JsonProperty("recentWarningsAutoMuteThresholds")]
-        public Dictionary<string, int> RecentWarningsAutoMuteThresholds { get; private set; }
+        public Dictionary<string, int> RecentWarningsAutoMuteThresholds { get; private set; } = new();
 
         [JsonProperty("insiderRoles")]
-        public List<ulong> InsiderRoles { get; private set; }
+        public List<ulong> InsiderRoles { get; private set; } = new();
 
         [JsonProperty("insiderChatRole")]
-        public ulong InsiderChatRole { get; private set; }
+        public ulong InsiderChatRole { get; private set; } = 0;
 
         [JsonProperty("giveawaysRole")]
-        public ulong GiveawaysRole { get; private set; }
+        public ulong GiveawaysRole { get; private set; } = 0;
 
         [JsonProperty("restrictedWords")]
-        public List<string> RestrictedWords { get; private set; }
+        public List<string> RestrictedWords { get; private set; } = new();
 
         [JsonProperty("massMentionThreshold")]
-        public int MassMentionThreshold { get; private set; }
+        public int MassMentionThreshold { get; private set; } = 0;
 
         [JsonProperty("massEmojiThreshold")]
-        public int MassEmojiThreshold { get; private set; }
+        public int? MassEmojiThreshold { get; private set; } = 0;
 
         [JsonProperty("tierRoles")]
-        public List<ulong> TierRoles { get; private set; }
+        public List<ulong> TierRoles { get; private set; } = new();
 
         [JsonProperty("inviteExclusion")]
-        public List<string> InviteExclusion { get; private set; }
+        public List<string> InviteExclusion { get; private set; } = new();
 
         [JsonProperty("inviteIDExclusion")]
-        public List<ulong> InviteIDExclusion { get; private set; }
+        public List<ulong> InviteIDExclusion { get; private set; } = new();
 
         [JsonProperty("inviteTierRequirement")]
-        public int InviteTierRequirement { get; private set; }
+        public int InviteTierRequirement { get; private set; } = 0;
 
         [JsonProperty("unrestrictedEmojiChannels")]
-        public List<ulong> UnrestrictedEmojiChannels { get; private set; }
+        public List<ulong> UnrestrictedEmojiChannels { get; private set; } = new();
 
         [JsonProperty("wordLists")]
-        public List<WordListJson> WordListList { get; private set; }
+        public List<WordListJson> WordListList { get; private set; } = new();
 
         [JsonProperty("lockdownEnabledChannels")]
-        public List<ulong> LockdownEnabledChannels { get; private set; }
+        public List<ulong> LockdownEnabledChannels { get; private set; } = new();
 
         [JsonProperty("publicFacingChannels")]
-        public List<ulong> PublicFacingChannels { get; private set; }
+        public List<ulong> PublicFacingChannels { get; private set; } = new();
 
         [JsonProperty("heartosoftId")]
-        public ulong HeartosoftId { get; private set; }
+        public ulong HeartosoftId { get; private set; } = 0;
 
         [JsonProperty("autoDehoistCharacters")]
-        public string AutoDehoistCharacters { get; private set; }
+        public string AutoDehoistCharacters { get; private set; } = "";
 
         [JsonProperty("investigationsChannel")]
-        public ulong InvestigationsChannelId { get; private set; }
+        public ulong InvestigationsChannelId { get; private set; } = 0;
 
         [JsonProperty("appealLink")]
-        public string AppealLink { get; private set; }
+        public string AppealLink { get; private set; } = "";
 
         [JsonProperty("communityTechSupportRoleID")]
-        public ulong CommunityTechSupportRoleID { get; private set; }
+        public ulong CommunityTechSupportRoleID { get; private set; } = 0;
 
         [JsonProperty("techSupportChannel")]
         public ulong TechSupportChannel { get; private set; } = 0;
@@ -111,13 +111,13 @@
         public ulong SupportLogChannel { get; private set; } = 0;
 
         [JsonProperty("supportRatelimitMinutes")]
-        public int SupportRatelimitMinutes { get; private set; }
+        public int SupportRatelimitMinutes { get; private set; } = 1;
 
         [JsonProperty("massMentionBanThreshold")]
-        public int MassMentionBanThreshold { get; private set; }
+        public int MassMentionBanThreshold { get; private set; } = 0;
 
         [JsonProperty("secondaryAutoDehoistCharacters")]
-        public string SecondaryAutoDehoistCharacters { get; private set; }
+        public string SecondaryAutoDehoistCharacters { get; private set; } = "";
 
         [JsonProperty("modmailUserId")]
         public ulong ModmailUserId { get; private set; } = 0;
@@ -126,28 +126,28 @@
         public string HastebinEndpoint { get; private set; } = "";
 
         [JsonProperty("modmailCategory")]
-        public ulong ModmailCategory { get; private set; }
+        public ulong ModmailCategory { get; private set; } = 0;
 
         [JsonProperty("lineLimit")]
-        public int LineLimit { get; private set; }
+        public int LineLimit { get; private set; } = 0;
 
         [JsonProperty("increasedLineLimit")]
-        public int IncreasedLineLimit { get; private set; }
+        public int IncreasedLineLimit { get; private set; } = 0;
 
         [JsonProperty("lineLimitTier")]
-        public int LineLimitTier { get; private set; }
+        public int LineLimitTier { get; private set; } = 0;
 
         [JsonProperty("lineLimitExcludedChannels")]
-        public List<ulong> LineLimitExcludedChannels { get; private set; }
+        public List<ulong> LineLimitExcludedChannels { get; private set; } = new();
 
         [JsonProperty("giveawaysChannel")]
         public ulong GiveawaysChannel { get; private set; } = 0;
 
         [JsonProperty("giveawayBot")]
-        public ulong GiveawayBot { get; private set; }
+        public ulong GiveawayBot { get; private set; } = 0;
 
         [JsonProperty("giveawayTriggerMessage")]
-        public string GiveawayTriggerMessage { get; private set; }
+        public string GiveawayTriggerMessage { get; private set; } = "";
 
         [JsonProperty("githubWorkflow")]
         public WorkflowConfig GitHubWorkflow { get; private set; } = default;
@@ -159,7 +159,7 @@
         public List<ulong> EveryoneExcludedChannels { get; private set; } = new();
 
         [JsonProperty("gitListDirectory")]
-        public string GitListDirectory { get; private set; }
+        public string GitListDirectory { get; private set; } = "";
 
         [JsonProperty("dmLogChannelId")]
         public ulong DmLogChannelId { get; private set; } = 0;
@@ -174,7 +174,7 @@
         public bool EveryoneFilter { get; private set; } = false;
 
         [JsonProperty("logChannels")]
-        public Dictionary<string, LogChannelConfig> LogChannels { get; private set; }
+        public Dictionary<string, LogChannelConfig> LogChannels { get; private set; } = new();
 
         [JsonProperty("botOwners")]
         public List<ulong> BotOwners { get; private set; } = new();
@@ -198,12 +198,12 @@
         public ulong FeedbackHubForum { get; private set; } = 0;
 
         [JsonProperty("insiderInfoChannel")]
-        public ulong InsiderInfoChannel { get; private set; }
+        public ulong InsiderInfoChannel { get; private set; } = 0;
 
         [JsonProperty("insiderAnnouncementChannel")]
         public ulong InsiderAnnouncementChannel { get; private set; } = 0;
 
-        private ulong insidersChannel;
+        private ulong insidersChannel = 0;
         [JsonProperty("insidersChannel")]
         public ulong InsidersChannel
         {
@@ -227,16 +227,16 @@
         public ulong TqsMutedRole { get; private set; } = 0;
 
         [JsonProperty("tqsMuteDurationHours")]
-        public int TqsMuteDurationHours { get; private set; }
+        public int TqsMuteDurationHours { get; private set; } = 0;
 
         [JsonProperty("autoWarnMsgAutoDeleteDays")]
-        public int AutoWarnMsgAutoDeleteDays { get; private set; }
+        public int AutoWarnMsgAutoDeleteDays { get; private set; } = 0;
 
         [JsonProperty("autoWarnMsgAutoDeleteHours")]
-        public int AutoWarnMsgAutoDeleteHours { get; private set; }
+        public int AutoWarnMsgAutoDeleteHours { get; private set; } = 0;
 
         [JsonProperty("compromisedAccountBanMsgAutoDeleteDays")]
-        public int CompromisedAccountBanMsgAutoDeleteDays { get; private set; }
+        public int CompromisedAccountBanMsgAutoDeleteDays { get; private set; } = 0;
 
         [JsonProperty("logLevel")]
         public Level LogLevel { get; private set; } = Level.Information;
@@ -248,7 +248,7 @@
         public string LokiServiceName { get; private set; } = null;
 
         [JsonProperty("voiceChannelPurge")]
-        public bool VoiceChannelPurge { get; private set; } = true;
+        public bool VoiceChannelPurge { get; private set; } = false;
 
         [JsonProperty("forumChannelAutoWarnFallbackChannel")]
         public ulong ForumChannelAutoWarnFallbackChannel { get; private set; } = 0;
@@ -266,7 +266,7 @@
         public string GithubWorkflowSucessString { get; private set; } = "";
 
         [JsonProperty("botCommandsChannel")]
-        public ulong BotCommandsChannel { get; private set; }
+        public ulong BotCommandsChannel { get; private set; } = 0;
 
         [JsonProperty("duplicateMessageThreshold")]
         public int DuplicateMessageThreshold { get; private set; } = 0;
@@ -278,7 +278,7 @@
         public int InsiderThreadKeepLastPins { get; private set; } = 50; // 50 is the pin limit, so it would be silly to allow infinite
 
         [JsonProperty("warningLogReactionTimeMinutes")]
-        public int WarningLogReactionTimeMinutes { get; private set; }
+        public int WarningLogReactionTimeMinutes { get; private set; } = 0;
 
         [JsonProperty("enablePersistentDb")]
         public bool EnablePersistentDb { get; set; } = false;
@@ -302,7 +302,7 @@
         public List<ulong> MessageLogExcludedChannels { get; set; } = new();
 
         [JsonProperty("reactionEmoji")]
-        public ReactionEmojiConfig ReactionEmoji { get; set; }
+        public ReactionEmojiConfig ReactionEmoji { get; set; } = null;
 
         [JsonProperty("autoModRules")]
         public List<AutoModRuleConfig> AutoModRules { get; set; } = new();
@@ -323,10 +323,10 @@
     public class AutoModRuleConfig
     {
         [JsonProperty("ruleId")]
-        public ulong RuleId { get; private set; }
+        public ulong RuleId { get; private set; } = 0;
 
         [JsonProperty("action")]
-        public string Action { get; private set; }
+        public string Action { get; private set; } = "";
 
         [JsonProperty("reason")]
         public string Reason { get; private set; } = "Automod rule violation";
@@ -335,30 +335,30 @@
     public class WorkflowConfig
     {
         [JsonProperty("repo")]
-        public string Repo { get; private set; }
+        public string Repo { get; private set; } = "";
 
         [JsonProperty("ref")]
-        public string Ref { get; private set; }
+        public string Ref { get; private set; } = "";
 
         [JsonProperty("workflowId")]
-        public string WorkflowId { get; private set; }
+        public string WorkflowId { get; private set; } = "";
     }
 
     public class WordListJson
     {
         [JsonProperty("name")]
-        public string Name { get; private set; }
+        public string Name { get; private set; } = "";
 
         [JsonProperty("wholeWord")]
-        public bool WholeWord { get; private set; }
+        public bool WholeWord { get; private set; } = false;
 
         [JsonProperty("url")]
-        public bool Url { get; private set; }
+        public bool Url { get; private set; } = false;
 
         [JsonProperty("reason")]
-        public string Reason { get; private set; }
+        public string Reason { get; private set; } = "";
 
-        public string[] Words { get; set; }
+        public string[] Words { get; set; } = [];
 
         [JsonProperty("excludedChannels")]
         public List<ulong> ExcludedChannels { get; private set; } = new();
@@ -367,102 +367,102 @@
         public bool Passive { get; private set; } = false;
 
         [JsonProperty("channelId")]
-        public ulong? ChannelId { get; private set; }
+        public ulong? ChannelId { get; private set; } = null;
     }
     public class EmojiJson
     {
         [JsonProperty("noPermissions")]
-        public string NoPermissions { get; set; }
+        public string NoPermissions { get; set; } = "🚫";
 
         [JsonProperty("warning")]
-        public string Warning { get; set; }
+        public string Warning { get; set; } = "⚠️";
 
         [JsonProperty("error")]
-        public string Error { get; set; }
+        public string Error { get; set; } = "✖️";
 
         [JsonProperty("deleted")]
-        public string Deleted { get; set; }
+        public string Deleted { get; set; } = "🚮";
 
         [JsonProperty("information")]
-        public string Information { get; set; }
+        public string Information { get; set; } = "ℹ️";
 
         [JsonProperty("muted")]
-        public string Muted { get; set; }
+        public string Muted { get; set; } = "🔇";
 
         [JsonProperty("denied")]
-        public string Denied { get; set; }
+        public string Denied { get; set; } = "⛔";
 
         [JsonProperty("banned")]
-        public string Banned { get; set; }
+        public string Banned { get; set; } = "⛔";
 
         [JsonProperty("unbanned")]
-        public string Unbanned { get; set; }
+        public string Unbanned { get; set; } = "🔄";
 
         [JsonProperty("ejected")]
-        public string Ejected { get; set; }
+        public string Ejected { get; set; } = "⏏️";
 
         [JsonProperty("loading")]
-        public string Loading { get; set; }
+        public string Loading { get; set; } = "🔄";
 
         [JsonProperty("success")]
-        public string Success { get; set; }
+        public string Success { get; set; } = "✅";
 
         [JsonProperty("locked")]
-        public string Locked { get; set; }
+        public string Locked { get; set; } = "🔒";
 
         [JsonProperty("connected")]
-        public string Connected { get; set; }
+        public string Connected { get; set; } = "🔗";
 
         [JsonProperty("help")]
-        public string Help { get; set; }
+        public string Help { get; set; } = "🆘";
 
         [JsonProperty("shieldHelp")]
-        public string ShieldHelp { get; set; }
+        public string ShieldHelp { get; set; } = "🆘";
 
         [JsonProperty("shieldMicrosoft")]
-        public string ShieldMicrosoft { get; set; }
+        public string ShieldMicrosoft { get; set; } = "";
 
         [JsonProperty("unlock")]
-        public string Unlock { get; set; }
+        public string Unlock { get; set; } = "🔓";
 
         [JsonProperty("bsod")]
-        public string BSOD { get; set; }
+        public string BSOD { get; set; } = "💢";
 
         [JsonProperty("userJoin")]
-        public string UserJoin { get; set; }
+        public string UserJoin { get; set; } = "📥";
 
         [JsonProperty("userLeave")]
-        public string UserLeave { get; set; }
+        public string UserLeave { get; set; } = "📤";
 
         [JsonProperty("userUpdate")]
-        public string UserUpdate { get; set; }
+        public string UserUpdate { get; set; } = "👤";
 
         [JsonProperty("messageEdit")]
-        public string MessageEdit { get; set; }
+        public string MessageEdit { get; set; } = "✏️";
 
         [JsonProperty("clockTime")]
-        public string ClockTime { get; set; }
+        public string ClockTime { get; set; } = "⏰️";
 
         [JsonProperty("windows11")]
-        public string Windows11 { get; set; }
+        public string Windows11 { get; set; } = "";
 
         [JsonProperty("on")]
-        public string On { get; set; }
+        public string On { get; set; } = "☑️";
 
         [JsonProperty("off")]
-        public string Off { get; set; }
+        public string Off { get; set; } = "✖️";
 
         [JsonProperty("insider")]
-        public string Insider { get; set; }
+        public string Insider { get; set; } = "";
     }
 
     public class CoreConfig
     {
         [JsonProperty("token")]
-        public string Token { get; private set; }
+        public string Token { get; private set; } = null;
 
         [JsonProperty("prefixes")]
-        public List<string> Prefixes { get; private set; }
+        public List<string> Prefixes { get; private set; } = ["!"];
     }
 
     public class RedisConfig


### PR DESCRIPTION
Sets fallback/default values for config.json in Types/Config.cs, so that missing configuration values won't blow up the bot. This should cover everything that's currently in config. Friendly errors are shown instead of exceptions when a missing config value is required, or for critical values (bot token etc.) an ArgumentException is thrown (all of these are before the logger is configured).